### PR TITLE
Enables multi-line world-info.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6732,7 +6732,7 @@ Current version: 27
 		<input class="form-control wiinputkey" id="wikey`+ i + `" placeholder="Key(s)" value="` + winame + `">
 		<input class="form-control wiinputkey `+ (curr.selective ? `` : `hidden`) + `" id="wikeysec` + i + `" placeholder="Sec. Key(s)" value="` + wisec + `">` + `</td>
 		<td class="col-10">
-		<input class="form-control wiinputval" id="wival`+ i + `" placeholder="What To Remember" value="` + witxt + `">
+		<textarea class="form-control wiinputval" id="wival`+ i + `" placeholder="What To Remember" rows="5">` + witxt + `</textarea>
 		</td>`+
 				`
 		<td>


### PR DESCRIPTION
This is a tweak I've been applying to my own `kobold.cpp` copy of Kobold Lite, but it has become onerous due to frequent updates (my merge tool sucks with resolving conflicts in minified source code).

This just allows world-info to be multi-line, which is kind of important for certain kinds of models that benefit from extraneous formatting (like instruct models).  I don't see any reason why it ever should have been an `<input>` instead of a `<textarea>` and it all works and looks fine just switching the elements over, since the JS APIs used by Kobold Lite are congruent between them.