### PR TITLE
Added optional aesthetic mode for UI of Instruct mode.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2811,7 +2811,7 @@ Current version: 53
 		case_sensitive_wi: false,
 		last_selected_preset: 0,
 		enhanced_chat_ui: true,
-		enhanced_chat_ui_instruct: false,
+		enhanced_instruct_ui: false,
 		multiline_replies: false,
 		allow_continue_chat: false,
 		idle_responses: 0,
@@ -4071,7 +4071,7 @@ Current version: 53
 		}
 		if(temp_scenario.opmode == 4)
 		{
-			if (temp_scenario.enhanced_chat_ui_instruct) { localsettings.enhanced_chat_ui_instruct = temp_scenario.enhanced_chat_ui; }
+			if (temp_scenario.enhanced_instruct_ui) { localsettings.enhanced_instruct_ui = temp_scenario.enhanced_chat_ui; }
 			if (temp_scenario.instruct_starttag) { localsettings.instruct_starttag = temp_scenario.instruct_starttag; }
 			if (temp_scenario.instruct_endtag) { localsettings.instruct_endtag = temp_scenario.instruct_endtag; }
 		}
@@ -5222,7 +5222,7 @@ Current version: 53
 		document.getElementById("tfs_s").value = localsettings.tfs_s;
 		document.getElementById("generate_images").value = localsettings.generate_images;
 		document.getElementById("enhanced_chat_ui").checked = localsettings.enhanced_chat_ui;
-		document.getElementById("enhanced_chat_ui_instruct").checked = localsettings.enhanced_chat_ui_instruct;
+		document.getElementById("enhanced_instruct_ui").checked = localsettings.enhanced_instruct_ui;
 		document.getElementById("multiline_replies").checked = localsettings.multiline_replies;
 		document.getElementById("allow_continue_chat").checked = localsettings.allow_continue_chat;
 		document.getElementById("idle_responses").value = localsettings.idle_responses;
@@ -5381,7 +5381,7 @@ Current version: 53
 		localsettings.trimwhitespace = (document.getElementById("trimwhitespace").checked ? true : false);
 		localsettings.persist_session = (document.getElementById("persist_session").checked ? true : false);
 		localsettings.enhanced_chat_ui = (document.getElementById("enhanced_chat_ui").checked ? true : false);
-		localsettings.enhanced_chat_ui_instruct = (document.getElementById("enhanced_chat_ui_instruct").checked ? true : false);
+		localsettings.enhanced_instruct_ui = (document.getElementById("enhanced_instruct_ui").checked ? true : false);
 		localsettings.multiline_replies = (document.getElementById("multiline_replies").checked ? true : false);
 		localsettings.allow_continue_chat = (document.getElementById("allow_continue_chat").checked ? true : false);
 		localsettings.idle_responses = document.getElementById("idle_responses").value;
@@ -7603,7 +7603,7 @@ Current version: 53
 		}
 
 		// Render onto enhanced chat interface if selected. Currently only applicable to Chat & Instruct modes.
-		let isStyleApplicable = (localsettings.opmode == 3 && localsettings.enhanced_chat_ui) || (localsettings.opmode == 4 && localsettings.enhanced_chat_ui_instruct);
+		let isStyleApplicable = (localsettings.opmode == 3 && localsettings.enhanced_chat_ui) || (localsettings.opmode == 4 && localsettings.enhanced_instruct_ui);
 		let inEditMode = (document.getElementById("allowediting").checked ? true : false);
 		if (localsettings.enhanced_chat_ui && !inEditMode && isStyleApplicable)
 		{
@@ -8709,8 +8709,8 @@ Current version: 53
 									</tr>
 								</table>
 								<div class="settinglabel">
-									<div class="justifyleft settingsmall" title="Switches to an aesthetic messenger style UI.">Aesthetic Chat UI </div>
-									<input type="checkbox" id="enhanced_chat_ui_instruct" style="margin:0px 0 0;">
+									<div class="justifyleft settingsmall" title="Switches to a UI style more suitable for RP. Enabling markdown together with this is recommended.">Aesthetic Instruct UI </div>
+									<input type="checkbox" id="enhanced_instruct_ui" style="margin:0px 0 0;">
 								</div>
 								<div class="justifyleft settingsmall">Enable Markdown <span class="helpicon">?<span
 									class="helptext">Allows the UI to use markdown formatting such as quotes and code blocks.</span></span> </div>

--- a/index.html
+++ b/index.html
@@ -7607,14 +7607,14 @@ Current version: 53
 		let inEditMode = (document.getElementById("allowediting").checked ? true : false);
 		if (localsettings.enhanced_chat_ui && !inEditMode && isStyleApplicable)
 		{
-			let textToRender = gametext_arr.length == 0 ? document.getElementById("gametext").innerHTML : concat_gametext(false, "", "", "", true);
+			let textToRender = (gametext_arr.length == 0 ? document.getElementById("gametext").innerHTML : concat_gametext(false, "", "", "", true));
 			if (localsettings.opmode == 3) { render_enhanced_chat(textToRender); }
 			else if (localsettings.opmode == 4) { render_enhanced_chat_instruct(textToRender); }
 
 			// Show the 'AI is typing' message if an answer is pending, and prevent the 'send button' from being clicked again.
-			if (!pending_response_id) { document.getElementById("chatistyping").classList.add("hidden"); }
+			if (pending_response_id=="") { document.getElementById("chatistyping").classList.add("hidden"); }
 			else {
-				let aiName = (pending_context_preinjection && pending_context_preinjection.includes(":")) ? pending_context_preinjection.split(":")[0] : "The AI";
+				let aiName = ((pending_context_preinjection && pending_context_preinjection.includes(":")) ? pending_context_preinjection.split(":")[0] : "The AI");
 				document.getElementById("chataityping").innerText = aiName + " is typing...";
 				document.getElementById("chatistyping").classList.remove("hidden");
 			}
@@ -7772,7 +7772,7 @@ Current version: 53
 	{
 		var chatbody = document.getElementById("chat_msg_body");
 		if (!chatbody) { return; }
-		
+
 		let you = get_instruct_starttag(); let bot = get_instruct_endtag(); // Instruct tags will be used to wrap text in styled bubbles.
 		let sysStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 40, 40, 0.8)'><p style='opacity:.8'>`;
 		let youStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%'><p>`;

--- a/index.html
+++ b/index.html
@@ -4017,9 +4017,12 @@ Current version: 52
 
 		localsettings.opmode = temp_scenario.opmode;
 		if (temp_scenario.opmode == 3) {
-			localsettings.enhanced_chat_ui = temp_scenario.enhanced_chat_ui;
-			localsettings.multiline_replies = temp_scenario.multiline_replies;
-			
+			if (temp_scenario.enhanced_chat_ui===true) { localsettings.enhanced_chat_ui = true; }
+			else if(temp_scenario.enhanced_chat_ui===false) { localsettings.enhanced_chat_ui = false; }
+
+			if (temp_scenario.multiline_replies===true) { localsettings.multiline_replies = true; }
+			else if(temp_scenario.multiline_replies===false) { localsettings.multiline_replies = false; }
+
 			if (temp_scenario.chatopponent) { localsettings.chatopponent = temp_scenario.chatopponent; }
 			if (temp_scenario.chatname) { localsettings.chatname = temp_scenario.chatname; }
 		}
@@ -4044,7 +4047,7 @@ Current version: 52
 		}
 		if(temp_scenario.opmode == 4)
 		{
-			localsettings.enhanced_chat_ui = temp_scenario.enhanced_chat_ui;
+			if (localsettings.enhanced_chat_ui) { localsettings.enhanced_chat_ui = temp_scenario.enhanced_chat_ui; }
 			if (temp_scenario.instruct_starttag) { localsettings.instruct_starttag = temp_scenario.instruct_starttag; }
 			if (temp_scenario.instruct_endtag) { localsettings.instruct_endtag = temp_scenario.instruct_endtag; }
 		}

--- a/index.html
+++ b/index.html
@@ -4017,26 +4017,11 @@ Current version: 52
 
 		localsettings.opmode = temp_scenario.opmode;
 		if (temp_scenario.opmode == 3) {
-			if (temp_scenario.enhanced_chat_ui===true) {
-				localsettings.enhanced_chat_ui = true;
-			}
-			else if(temp_scenario.enhanced_chat_ui===false)
-			{
-				localsettings.enhanced_chat_ui = false;
-			}
-			if (temp_scenario.multiline_replies===true) {
-				localsettings.multiline_replies = true;
-			}
-			else if(temp_scenario.multiline_replies===false)
-			{
-				localsettings.multiline_replies = false;
-			}
-			if (temp_scenario.chatopponent) {
-				localsettings.chatopponent = temp_scenario.chatopponent;
-			}
-			if (temp_scenario.chatname) {
-				localsettings.chatname = temp_scenario.chatname;
-			}
+			localsettings.enhanced_chat_ui = temp_scenario.enhanced_chat_ui;
+			localsettings.multiline_replies = temp_scenario.multiline_replies;
+			
+			if (temp_scenario.chatopponent) { localsettings.chatopponent = temp_scenario.chatopponent; }
+			if (temp_scenario.chatname) { localsettings.chatname = temp_scenario.chatname; }
 		}
 		if(temp_scenario.opmode == 2)
 		{
@@ -4059,12 +4044,9 @@ Current version: 52
 		}
 		if(temp_scenario.opmode == 4)
 		{
-			if (temp_scenario.instruct_starttag) {
-				localsettings.instruct_starttag = temp_scenario.instruct_starttag;
-			}
-			if (temp_scenario.instruct_endtag) {
-				localsettings.instruct_endtag = temp_scenario.instruct_endtag;
-			}
+			localsettings.enhanced_chat_ui = temp_scenario.enhanced_chat_ui;
+			if (temp_scenario.instruct_starttag) { localsettings.instruct_starttag = temp_scenario.instruct_starttag; }
+			if (temp_scenario.instruct_endtag) { localsettings.instruct_endtag = temp_scenario.instruct_endtag; }
 		}
 
 		render_gametext();
@@ -7591,18 +7573,15 @@ Current version: 52
 			document.getElementById("fvico").href = favicon_busy;
 		}
 
-		//render onto enhanced chat interface if selected
-		let inEditMode = (document.getElementById("allowediting").checked?true:false);
-		if(localsettings.enhanced_chat_ui && localsettings.opmode==3 &&!inEditMode)
+		//render onto enhanced chat interface if selected. Currently only applicable to Chat & Instruct modes.
+		let isStyleApplicable = localsettings.opmode == 3 || localsettings.opmode == 4;
+		let inEditMode = (document.getElementById("allowediting").checked ? true : false);
+		if (localsettings.enhanced_chat_ui && !inEditMode && isStyleApplicable)
 		{
-			if(gametext_arr.length == 0)
-			{
-				render_enhanced_chat(document.getElementById("gametext").innerHTML);
-			}
-			else
-			{
-				render_enhanced_chat(concat_gametext(false,"","","",true));
-			}
+			let textToRender = gametext_arr.length == 0 ? document.getElementById("gametext").innerHTML : concat_gametext(false, "", "", "", true);
+			if (localsettings.opmode == 3) { render_enhanced_chat(textToRender); }
+			else if (localsettings.opmode == 4) { render_enhanced_chat_instruct(textToRender); }
+
 			document.getElementById("enhancedchatinterface").classList.remove("hidden");
 			document.getElementById("normalinterface").classList.add("hidden");
 		}else{
@@ -7767,6 +7746,33 @@ Current version: 52
 
 		document.getElementById("chat_msg_send_btn").disabled = document.getElementById("btnsend").disabled;
 
+	}
+
+	function render_enhanced_chat_instruct(input)
+	{
+		var chatbody = document.getElementById("chat_msg_body");
+		if(!chatbody) { return; }
+
+		let you = get_instruct_starttag(); let bot = get_instruct_endtag();
+		let newbodystr = input.replaceAll(you + '\n', you).replaceAll(bot + '\n', bot).replaceAll(you + ' ', you).replaceAll(bot + ' ', bot);
+		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }
+		
+		// Style *Expressions* and "Speech". TODO: Add customization options
+		newbodystr = newbodystr.replaceAll(/&quot;(\S[^*]+\S)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
+		newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,"<em style='opacity:0.7'>$1</em>");
+		
+		let youStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg"><div class="chat_received_withd_msg"><p>`;
+		let botStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg"><div class="chat_received_withd_msg" style='background-color:rgba(20, 20, 40, 0.4)'><p>`;
+		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);		// Style incoming messages and outcoming messages appropriately.
+		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	// Replace the HTML and handle newlines as needed.
+
+		// Show the 
+		if (pending_response_id == "") { document.getElementById("chatistyping").classList.add("hidden"); }
+		else {
+			document.getElementById("chatistyping").classList.remove("hidden");
+			document.getElementById("chataityping").innerText = "The AI is typing...";
+		}
+		document.getElementById("chat_msg_send_btn").disabled = document.getElementById("btnsend").disabled;
 	}
 
 	function chat_handle_typing(event)
@@ -8187,8 +8193,7 @@ Current version: 52
 		</div>
 
 		<div id="enhancedchatinterface" class="chat_mesgs hidden">
-			<div id="chat_msg_body" class="chat_msg_history">
-			</div>
+			<div id="chat_msg_body" class="chat_msg_history"></div>
 			<div class="hidden" id="chatistyping" style="text-align:right;font-size:13px;color:#999999; padding-bottom: 3px;"><div style="padding-bottom: 2px;" id="chataityping">The AI is typing...</div><div style="padding-top:2px;text-align:right;" class="dot-flashing flex flex-push-right"></div></div>
 
 			<!-- A greatly simplified action menu for this mode -->
@@ -8660,10 +8665,6 @@ Current version: 52
 								</tr>
 							  </table>
 							<div class="settinglabel">
-							<div class="justifyleft settingsmall" title="Switches to an aesthetic messenger style UI">Aesthetic Chat UI </div>
-							<input type="checkbox" id="enhanced_chat_ui" style="margin:0px 0 0;">
-							</div>
-							<div class="settinglabel">
 							<div class="justifyleft settingsmall" title="Whether to allow multiple lines in AI responses. Not recommended.">Multiline Replies </div>
 							<input type="checkbox" id="multiline_replies" style="margin:0px 0 0;">
 							</div>
@@ -8679,7 +8680,18 @@ Current version: 52
 							   <input type="checkbox" id="adventure_context_mod" style="margin:0px 0 0;">
 							</div>
 							<div id="instructsection" class="settinglabel hidden" style="padding-top: 3px;">
-
+								<!-- TODO: Allow selecting name and picture for yourself and AI. This could be embeded on the left of each message.
+								<table class="settingsmall text-center" style="border-spacing: 4px 2px;	border-collapse: separate;">
+									<tr>
+									  <th>You <a class="color_blueurl" href="#" onclick="selectYourPicture()">🎨</a></th>
+									  <th>AI <a class="color_blueurl" href="#" onclick="selectBotPicture()">🎨</a> <span class="helpicon">?<span class="helptext">The name of the person you want to chat with. Multiple opponents can be specified, creating a group chat, separate their names with ||$||</span></span></th>
+									</tr>
+									<tr>
+										<td><input class="settinglabel mininiput" type="text" placeholder="(Enter Name)" value="" id="chatname" title="The name that you will be chatting as"></td>
+										<td><input class="settinglabel mininiput" type="text" placeholder="(Auto)" value="" id="chatopponent"  title="The name of the person you want to chat with"></td>
+									</tr>
+								</table>
+								-->
 								<table class="settingsmall text-center" style="border-spacing: 4px 2px;	border-collapse: separate;">
 									<tr>
 									  <th>Start Seq.<span class="helpicon">?<span class="helptext">The sequence to start an instruction prompt</span></span></th>
@@ -8741,6 +8753,10 @@ Current version: 52
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall" title="Inverts all colors, simple light mode">Inverted Colors </div>
 						   <input type="checkbox" id="invert_colors" style="margin:0px 0 0;">
+						</div>
+						<div class="settinglabel">
+							<div class="justifyleft settingsmall" title="Switches to an aesthetic messenger style UI. Only applicable to Chat Mode & Instruct mode.">Aesthetic Chat UI </div>
+							<input type="checkbox" id="enhanced_chat_ui" style="margin:0px 0 0;">
 						</div>
 					</div>
 

--- a/index.html
+++ b/index.html
@@ -7757,11 +7757,13 @@ Current version: 52
 
 		// We'll transform the input to a well-formatted HTML string. First, trim any newline characters after seq_start and seq_end.
 		let newbodystr = sysStyle + input.replaceAll(you + '\n', you).replaceAll(bot + '\n', bot).replaceAll(you + ' ', you).replaceAll(bot + ' ', bot);
-		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }		  // Remove the last endtag if it exists.
-		newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,`<em style='opacity:0.7'>$1</em>`); // Style *Expressions* and "Speech". TODO: Add customization options
-		newbodystr = newbodystr.replaceAll(/&quot;(.*?)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
-		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);			  // Style incoming messages and outcoming messages appropriately.
-		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	      // Replace the HTML and handle newlines as needed.
+		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }		  	  // Remove the last endtag if it exists.
+		if (localsettings.instruct_has_markdown) {													  // Style *Expressions* and "Speech" if markdown is toggled.
+			newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,`<em style='opacity:0.7'>$1</em>`);
+			newbodystr = newbodystr.replaceAll(/&quot;(.*?)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
+		}
+		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);			  	  // Style incoming messages and outcoming messages appropriately.
+		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	          // Replace the HTML and handle newlines as needed.
 	}
 
 	function chat_handle_typing(event)
@@ -8673,18 +8675,6 @@ Current version: 52
 							   <input type="checkbox" id="adventure_context_mod" style="margin:0px 0 0;">
 							</div>
 							<div id="instructsection" class="settinglabel hidden" style="padding-top: 3px;">
-								<!-- TODO: Allow selecting name and picture for yourself and AI. This could be embeded on the left of each message.
-								<table class="settingsmall text-center" style="border-spacing: 4px 2px;	border-collapse: separate;">
-									<tr>
-									  <th>You <a class="color_blueurl" href="#" onclick="selectYourPicture()">🎨</a></th>
-									  <th>AI <a class="color_blueurl" href="#" onclick="selectBotPicture()">🎨</a> <span class="helpicon">?<span class="helptext">The name of the person you want to chat with. Multiple opponents can be specified, creating a group chat, separate their names with ||$||</span></span></th>
-									</tr>
-									<tr>
-										<td><input class="settinglabel mininiput" type="text" placeholder="(Enter Name)" value="" id="chatname" title="The name that you will be chatting as"></td>
-										<td><input class="settinglabel mininiput" type="text" placeholder="(Auto)" value="" id="chatopponent"  title="The name of the person you want to chat with"></td>
-									</tr>
-								</table>
-								-->
 								<table class="settingsmall text-center" style="border-spacing: 4px 2px;	border-collapse: separate;">
 									<tr>
 										<th>Start Seq.<span class="helpicon">?<span class="helptext">The sequence to start an instruction prompt</span></span></th>

--- a/index.html
+++ b/index.html
@@ -7758,7 +7758,7 @@ Current version: 52
 		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }
 		
 		// Style *Expressions* and "Speech". TODO: Add customization options
-		newbodystr = newbodystr.replaceAll(/&quot;(\S[^*]+\S)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
+		newbodystr = newbodystr.replaceAll(/&quot;(.*?)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
 		newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,"<em style='opacity:0.7'>$1</em>");
 		
 		let youStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg"><div class="chat_received_withd_msg"><p>`;

--- a/index.html
+++ b/index.html
@@ -7776,17 +7776,18 @@ Current version: 53
 		let you = get_instruct_starttag(); let bot = get_instruct_endtag(); // Instruct tags will be used to wrap text in styled bubbles.
 		let sysStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 40, 40, 0.8)'><p style='opacity:.8'>`;
 		let youStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%'><p>`;
-		let botStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 20, 40, 0.4)'><p>`;
+		let botStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 20, 40, 1)'><p>`;
 
 		// We'll transform the input to a well-formatted HTML string. First, trim any newline characters after seq_start and seq_end.
 		let newbodystr = sysStyle + input.replaceAll(you + '\n', you).replaceAll(bot + '\n', bot).replaceAll(you + ' ', you).replaceAll(bot + ' ', bot);
-		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }		  	  // Remove the last endtag if it exists.
-		if (localsettings.instruct_has_markdown) {													  // Style *Expressions* and "Speech" if markdown is toggled.
+		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }  	// Remove the last endtag if it exists.
+		if (localsettings.instruct_has_markdown) {											// Style *Expressions*, "Speech", and code blocks if markdown is toggled.
 			newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,`<em style='opacity:0.7'>$1</em>`);
 			newbodystr = newbodystr.replaceAll(/&quot;(.*?)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
+			let blocks = newbodystr.split(/(```.*?\n[\s\S]*?```)/gs); for (var i = 0; i < blocks.length; i++) { if (blocks[i].startsWith("```")) { blocks[i] = blocks[i].replaceAll(/```.*?\n([\s\S]*?)```/gs, `</p><pre style='margin:0px 100px 0px 20px;background-color:black;color:rgba(120, 5, 30, 1)'>$1</pre><p>`); } else { blocks[i] = blocks[i].replaceAll("```","`").replaceAll("``","`").replaceAll(/`(.*?)`/g, `<code>$1</code>`);} } newbodystr = blocks.join('');
 		}
-		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);			  	  // Style incoming messages and outcoming messages appropriately.
-		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	          // Replace the HTML and handle newlines as needed.
+		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);	  	// Style incoming messages and outcoming messages appropriately.
+		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	// Replace the HTML and handle newlines as needed.
 	}
 
 	function chat_handle_typing(event)

--- a/index.html
+++ b/index.html
@@ -7766,7 +7766,7 @@ Current version: 52
 		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);		// Style incoming messages and outcoming messages appropriately.
 		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	// Replace the HTML and handle newlines as needed.
 
-		// Show the 
+		// Show the 'AI is typing' message if an answer is pending, and prevent the 'send button' from being clicked again.
 		if (pending_response_id == "") { document.getElementById("chatistyping").classList.add("hidden"); }
 		else {
 			document.getElementById("chatistyping").classList.remove("hidden");

--- a/index.html
+++ b/index.html
@@ -7573,7 +7573,7 @@ Current version: 52
 			document.getElementById("fvico").href = favicon_busy;
 		}
 
-		//render onto enhanced chat interface if selected. Currently only applicable to Chat & Instruct modes.
+		// Render onto enhanced chat interface if selected. Currently only applicable to Chat & Instruct modes.
 		let isStyleApplicable = localsettings.opmode == 3 || localsettings.opmode == 4;
 		let inEditMode = (document.getElementById("allowediting").checked ? true : false);
 		if (localsettings.enhanced_chat_ui && !inEditMode && isStyleApplicable)
@@ -7582,9 +7582,18 @@ Current version: 52
 			if (localsettings.opmode == 3) { render_enhanced_chat(textToRender); }
 			else if (localsettings.opmode == 4) { render_enhanced_chat_instruct(textToRender); }
 
+			// Show the 'AI is typing' message if an answer is pending, and prevent the 'send button' from being clicked again.
+			if (!pending_response_id) { document.getElementById("chatistyping").classList.add("hidden"); }
+			else {
+				let aiName = (pending_context_preinjection && pending_context_preinjection.includes(":")) ? pending_context_preinjection.split(":")[0] : "The AI";
+				document.getElementById("chataityping").innerText = aiName + " is typing...";
+				document.getElementById("chatistyping").classList.remove("hidden");
+			}
+			document.getElementById("chat_msg_send_btn").disabled = document.getElementById("btnsend").disabled;
+
 			document.getElementById("enhancedchatinterface").classList.remove("hidden");
 			document.getElementById("normalinterface").classList.add("hidden");
-		}else{
+		} else {
 			document.getElementById("enhancedchatinterface").classList.add("hidden");
 			document.getElementById("normalinterface").classList.remove("hidden");
 		}
@@ -7728,51 +7737,24 @@ Current version: 52
 		}
 
 		chatbody.innerHTML = newbodystr;
-
-		if(pending_response_id=="")
-		{
-			document.getElementById("chatistyping").classList.add("hidden");
-		}else{
-			document.getElementById("chatistyping").classList.remove("hidden");
-			if(pending_context_preinjection!=null && pending_context_preinjection!="" && pending_context_preinjection.includes(":"))
-			{
-				//use chatopponent name if we have it. do not read from settings as the inferred name may be different
-				document.getElementById("chataityping").innerText = pending_context_preinjection.split(":")[0] + " is typing...";
-			}else{
-				document.getElementById("chataityping").innerText = "The AI is typing...";
-			}
-
-		}
-
-		document.getElementById("chat_msg_send_btn").disabled = document.getElementById("btnsend").disabled;
-
 	}
 
 	function render_enhanced_chat_instruct(input)
 	{
 		var chatbody = document.getElementById("chat_msg_body");
-		if(!chatbody) { return; }
+		if (!chatbody) { return; }
+		
+		let you = get_instruct_starttag(); let bot = get_instruct_endtag(); // Instruct tags will be used to wrap text in styled bubbles.
+		let youStyle = `</p></div></div></div><div class="incoming_msg" style='width:100%'><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%'><p>`;
+		let botStyle = `</p></div></div></div><div class="incoming_msg" style='width:100%'><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 20, 40, 0.4)'><p>`;
 
-		let you = get_instruct_starttag(); let bot = get_instruct_endtag();
+		// We'll transform the input to a well-formatted HTML string. First, trim any newline characters after seq_start and seq_end.
 		let newbodystr = input.replaceAll(you + '\n', you).replaceAll(bot + '\n', bot).replaceAll(you + ' ', you).replaceAll(bot + ' ', bot);
-		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }
-		
-		// Style *Expressions* and "Speech". TODO: Add customization options
+		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }		  // Remove the last endtag if it exists.
+		newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,`<em style='opacity:0.7'>$1</em>`); // Style *Expressions* and "Speech". TODO: Add customization options
 		newbodystr = newbodystr.replaceAll(/&quot;(.*?)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
-		newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,"<em style='opacity:0.7'>$1</em>");
-		
-		let youStyle = `</p></div></div></div><div class="incoming_msg" style='width:100%><div class="chat_received_msg" style='width:100%><div class="chat_received_withd_msg" style='width:100%'><p>`;
-		let botStyle = `</p></div></div></div><div class="incoming_msg" style='width:100%><div class="chat_received_msg" style='width:100%><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 20, 40, 0.4)'><p>`;
-		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);		// Style incoming messages and outcoming messages appropriately.
-		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	// Replace the HTML and handle newlines as needed.
-
-		// Show the 'AI is typing' message if an answer is pending, and prevent the 'send button' from being clicked again.
-		if (pending_response_id == "") { document.getElementById("chatistyping").classList.add("hidden"); }
-		else {
-			document.getElementById("chatistyping").classList.remove("hidden");
-			document.getElementById("chataityping").innerText = "The AI is typing...";
-		}
-		document.getElementById("chat_msg_send_btn").disabled = document.getElementById("btnsend").disabled;
+		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);			  // Style incoming messages and outcoming messages appropriately.
+		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	      // Replace the HTML and handle newlines as needed.
 	}
 
 	function chat_handle_typing(event)

--- a/index.html
+++ b/index.html
@@ -7761,8 +7761,8 @@ Current version: 52
 		newbodystr = newbodystr.replaceAll(/&quot;(.*?)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
 		newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,"<em style='opacity:0.7'>$1</em>");
 		
-		let youStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg"><div class="chat_received_withd_msg"><p>`;
-		let botStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg"><div class="chat_received_withd_msg" style='background-color:rgba(20, 20, 40, 0.4)'><p>`;
+		let youStyle = `</p></div></div></div><div class="incoming_msg" style='width:100%><div class="chat_received_msg" style='width:100%><div class="chat_received_withd_msg" style='width:100%'><p>`;
+		let botStyle = `</p></div></div></div><div class="incoming_msg" style='width:100%><div class="chat_received_msg" style='width:100%><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 20, 40, 0.4)'><p>`;
 		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);		// Style incoming messages and outcoming messages appropriately.
 		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	// Replace the HTML and handle newlines as needed.
 

--- a/index.html
+++ b/index.html
@@ -7784,7 +7784,7 @@ Current version: 53
 		if (localsettings.instruct_has_markdown) {											// Style *Expressions*, "Speech", and code blocks if markdown is toggled.
 			newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,`<em style='opacity:0.7'>$1</em>`);
 			newbodystr = newbodystr.replaceAll(/&quot;(.*?)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);
-			let blocks = newbodystr.split(/(```.*?\n[\s\S]*?```)/gs); for (var i = 0; i < blocks.length; i++) { if (blocks[i].startsWith("```")) { blocks[i] = blocks[i].replaceAll(/```.*?\n([\s\S]*?)```/gs, `</p><pre style='margin:0px 100px 0px 20px;background-color:black;color:rgba(120, 5, 30, 1)'>$1</pre><p>`); } else { blocks[i] = blocks[i].replaceAll("```","`").replaceAll("``","`").replaceAll(/`(.*?)`/g, `<code>$1</code>`);} } newbodystr = blocks.join('');
+			let blocks = newbodystr.split(/(```.*?\n[\s\S]*?```)/gs); for (var i = 0; i < blocks.length; i++) { if (blocks[i].startsWith("```")) { blocks[i] = blocks[i].replaceAll(/```.*?\n([\s\S]*?)```/gs, `</p><pre style='margin:0px 100px 0px 20px;background-color:black;color:rgba(180, 35, 40, 1)'>$1</pre><p>`); } else { blocks[i] = blocks[i].replaceAll("```","`").replaceAll("``","`").replaceAll(/`(.*?)`/g, `<code style='background-color:black'>$1</code>`);} } newbodystr = blocks.join('');
 		}
 		newbodystr = newbodystr.replaceAll(you, youStyle).replaceAll(bot, botStyle);	  	// Style incoming messages and outcoming messages appropriately.
 		chatbody.innerHTML = newbodystr.replaceAll('\r\n','<br>').replaceAll('\n','<br>');	// Replace the HTML and handle newlines as needed.

--- a/index.html
+++ b/index.html
@@ -8711,7 +8711,7 @@ Current version: 53
 								</table>
 								<div class="settinglabel">
 									<div class="justifyleft settingsmall" title="Switches to a UI style more suitable for RP. Enabling markdown together with this is recommended.">Aesthetic Instruct UI </div>
-									<input type="checkbox" id="enhanced_instruct_ui" style="margin:0px 0 0;">
+									<input type="checkbox" id="enhanced_instruct_ui" style="margin:0px 5.5px;">
 								</div>
 								<div class="justifyleft settingsmall">Enable Markdown <span class="helpicon">?<span
 									class="helptext">Allows the UI to use markdown formatting such as quotes and code blocks.</span></span> </div>

--- a/index.html
+++ b/index.html
@@ -2810,6 +2810,7 @@ Current version: 52
 		case_sensitive_wi: false,
 		last_selected_preset: 0,
 		enhanced_chat_ui: true,
+		enhanced_chat_ui_instruct: false,
 		multiline_replies: false,
 		allow_continue_chat: false,
 		idle_responses: 0,
@@ -4047,7 +4048,7 @@ Current version: 52
 		}
 		if(temp_scenario.opmode == 4)
 		{
-			if (localsettings.enhanced_chat_ui) { localsettings.enhanced_chat_ui = temp_scenario.enhanced_chat_ui; }
+			if (temp_scenario.enhanced_chat_ui_instruct) { localsettings.enhanced_chat_ui_instruct = temp_scenario.enhanced_chat_ui; }
 			if (temp_scenario.instruct_starttag) { localsettings.instruct_starttag = temp_scenario.instruct_starttag; }
 			if (temp_scenario.instruct_endtag) { localsettings.instruct_endtag = temp_scenario.instruct_endtag; }
 		}
@@ -5198,6 +5199,7 @@ Current version: 52
 		document.getElementById("tfs_s").value = localsettings.tfs_s;
 		document.getElementById("generate_images").value = localsettings.generate_images;
 		document.getElementById("enhanced_chat_ui").checked = localsettings.enhanced_chat_ui;
+		document.getElementById("enhanced_chat_ui_instruct").checked = localsettings.enhanced_chat_ui_instruct;
 		document.getElementById("multiline_replies").checked = localsettings.multiline_replies;
 		document.getElementById("allow_continue_chat").checked = localsettings.allow_continue_chat;
 		document.getElementById("idle_responses").value = localsettings.idle_responses;
@@ -5356,6 +5358,7 @@ Current version: 52
 		localsettings.trimwhitespace = (document.getElementById("trimwhitespace").checked ? true : false);
 		localsettings.persist_session = (document.getElementById("persist_session").checked ? true : false);
 		localsettings.enhanced_chat_ui = (document.getElementById("enhanced_chat_ui").checked ? true : false);
+		localsettings.enhanced_chat_ui_instruct = (document.getElementById("enhanced_chat_ui_instruct").checked ? true : false);
 		localsettings.multiline_replies = (document.getElementById("multiline_replies").checked ? true : false);
 		localsettings.allow_continue_chat = (document.getElementById("allow_continue_chat").checked ? true : false);
 		localsettings.idle_responses = document.getElementById("idle_responses").value;
@@ -7577,7 +7580,7 @@ Current version: 52
 		}
 
 		// Render onto enhanced chat interface if selected. Currently only applicable to Chat & Instruct modes.
-		let isStyleApplicable = localsettings.opmode == 3 || localsettings.opmode == 4;
+		let isStyleApplicable = (localsettings.opmode == 3 && localsettings.enhanced_chat_ui) || (localsettings.opmode == 4 && localsettings.enhanced_chat_ui_instruct);
 		let inEditMode = (document.getElementById("allowediting").checked ? true : false);
 		if (localsettings.enhanced_chat_ui && !inEditMode && isStyleApplicable)
 		{
@@ -8641,22 +8644,26 @@ Current version: 52
 							</select>
 							<div id="chatnamesection" class="hidden">
 								<table class="settingsmall text-center" style="border-spacing: 4px 2px;	border-collapse: separate;">
-								<tr>
-								  <th>Your Name</th>
-								  <th>AI Name <span class="helpicon">?<span class="helptext">The name of the person you want to chat with. Multiple opponents can be specified, creating a group chat, separate their names with ||$||</span></span></th>
-								</tr>
-								<tr>
-								<td><input class="settinglabel mininiput" type="text" placeholder="(Enter Name)" value="" id="chatname" title="The name that you will be chatting as"></td>
-								<td><input class="settinglabel mininiput" type="text" placeholder="(Auto)" value="" id="chatopponent"  title="The name of the person you want to chat with"></td>
-								</tr>
-							  </table>
-							<div class="settinglabel">
-							<div class="justifyleft settingsmall" title="Whether to allow multiple lines in AI responses. Not recommended.">Multiline Replies </div>
-							<input type="checkbox" id="multiline_replies" style="margin:0px 0 0;">
-							</div>
-							<div class="settinglabel">
-							<div class="justifyleft settingsmall" title="Allow incomplete AI chat replies, which can be continued by pressing submit again. Not recommended.">Continue Bot Replies</div>
-							<input type="checkbox" id="allow_continue_chat" style="margin:0px 0 0;">
+									<tr>
+										<th>Your Name</th>
+										<th>AI Name <span class="helpicon">?<span class="helptext">The name of the person you want to chat with. Multiple opponents can be specified, creating a group chat, separate their names with ||$||</span></span></th>
+									</tr>
+									<tr>
+										<td><input class="settinglabel mininiput" type="text" placeholder="(Enter Name)" value="" id="chatname" title="The name that you will be chatting as"></td>
+										<td><input class="settinglabel mininiput" type="text" placeholder="(Auto)" value="" id="chatopponent"  title="The name of the person you want to chat with"></td>
+									</tr>
+								</table>
+								<div class="settinglabel">
+									<div class="justifyleft settingsmall" title="Switches to an aesthetic messenger style UI.">Aesthetic Chat UI </div>
+									<input type="checkbox" id="enhanced_chat_ui" style="margin:0px 0 0;">
+								</div>
+								<div class="settinglabel">
+								<div class="justifyleft settingsmall" title="Whether to allow multiple lines in AI responses. Not recommended.">Multiline Replies </div>
+								<input type="checkbox" id="multiline_replies" style="margin:0px 0 0;">
+								</div>
+								<div class="settinglabel">
+								<div class="justifyleft settingsmall" title="Allow incomplete AI chat replies, which can be continued by pressing submit again. Not recommended.">Continue Bot Replies</div>
+								<input type="checkbox" id="allow_continue_chat" style="margin:0px 0 0;">
 							</div>
 
 							</div>
@@ -8680,15 +8687,18 @@ Current version: 52
 								-->
 								<table class="settingsmall text-center" style="border-spacing: 4px 2px;	border-collapse: separate;">
 									<tr>
-									  <th>Start Seq.<span class="helpicon">?<span class="helptext">The sequence to start an instruction prompt</span></span></th>
-									  <th>End Seq.<span class="helpicon">?<span class="helptext">The sequence to end an instruction prompt</span></span></th>
+										<th>Start Seq.<span class="helpicon">?<span class="helptext">The sequence to start an instruction prompt</span></span></th>
+										<th>End Seq.<span class="helpicon">?<span class="helptext">The sequence to end an instruction prompt</span></span></th>
 									</tr>
 									<tr>
-									<td><input class="settinglabel mininiput" type="text" placeholder="\\n### Instruction:\\n" value="" id="instruct_starttag" title="The sequence to start an instruction prompt"></td>
-									<td><input class="settinglabel mininiput" type="text" placeholder="\\n### Response:\\n" value="" id="instruct_endtag"  title="The sequence to end an instruction prompt"></td>
+										<td><input class="settinglabel mininiput" type="text" placeholder="\\n### Instruction:\\n" value="" id="instruct_starttag" title="The sequence to start an instruction prompt"></td>
+										<td><input class="settinglabel mininiput" type="text" placeholder="\\n### Response:\\n" value="" id="instruct_endtag"  title="The sequence to end an instruction prompt"></td>
 									</tr>
 								</table>
-
+								<div class="settinglabel">
+									<div class="justifyleft settingsmall" title="Switches to an aesthetic messenger style UI.">Aesthetic Chat UI </div>
+									<input type="checkbox" id="enhanced_chat_ui_instruct" style="margin:0px 0 0;">
+								</div>
 								<div class="justifyleft settingsmall">Enable Markdown <span class="helpicon">?<span
 									class="helptext">Allows the UI to use markdown formatting such as quotes and code blocks.</span></span> </div>
 								<input type="checkbox" id="instruct_has_markdown" style="margin:0px 0 0;">
@@ -8739,10 +8749,6 @@ Current version: 52
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall" title="Inverts all colors, simple light mode">Inverted Colors </div>
 						   <input type="checkbox" id="invert_colors" style="margin:0px 0 0;">
-						</div>
-						<div class="settinglabel">
-							<div class="justifyleft settingsmall" title="Switches to an aesthetic messenger style UI. Only applicable to Chat Mode & Instruct mode.">Aesthetic Chat UI </div>
-							<input type="checkbox" id="enhanced_chat_ui" style="margin:0px 0 0;">
 						</div>
 					</div>
 

--- a/index.html
+++ b/index.html
@@ -7748,11 +7748,12 @@ Current version: 52
 		if (!chatbody) { return; }
 		
 		let you = get_instruct_starttag(); let bot = get_instruct_endtag(); // Instruct tags will be used to wrap text in styled bubbles.
-		let youStyle = `</p></div></div></div><div class="incoming_msg" style='width:100%'><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%'><p>`;
-		let botStyle = `</p></div></div></div><div class="incoming_msg" style='width:100%'><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 20, 40, 0.4)'><p>`;
+		let sysStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 40, 40, 0.8)'><p style='opacity:.8'>`;
+		let youStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%'><p>`;
+		let botStyle = `</p></div></div></div><div class="incoming_msg"><div class="chat_received_msg" style='width:100%'><div class="chat_received_withd_msg" style='width:100%;background-color:rgba(20, 20, 40, 0.4)'><p>`;
 
 		// We'll transform the input to a well-formatted HTML string. First, trim any newline characters after seq_start and seq_end.
-		let newbodystr = input.replaceAll(you + '\n', you).replaceAll(bot + '\n', bot).replaceAll(you + ' ', you).replaceAll(bot + ' ', bot);
+		let newbodystr = sysStyle + input.replaceAll(you + '\n', you).replaceAll(bot + '\n', bot).replaceAll(you + ' ', you).replaceAll(bot + ' ', bot);
 		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }		  // Remove the last endtag if it exists.
 		newbodystr = newbodystr.replaceAll(/\*(\S[^*]+\S)\*/g,`<em style='opacity:0.7'>$1</em>`); // Style *Expressions* and "Speech". TODO: Add customization options
 		newbodystr = newbodystr.replaceAll(/&quot;(.*?)&quot;/g, `<em style='color:rgba(150, 150, 200, 1)'>"$1"</em>`);


### PR DESCRIPTION
**Changes:**
- 'Aesthetic UI' toggle (previously under 'Chat mode settings') is now on the right panel of the 'Format settings' tab.

**Additions:**
- 'Aesthetic UI' now affects Instruct mode as well.
- Aesthetic mode:
    - Text following the `seq_start` and `seq_end` is wrapped in chat bubbles and styled appropriately.
    - Text outside of chat bubbles (e.g. system messages) is slightly faded out.
    - Markdown mode is supported. If enabled, these settings apply:
        - Expressions (text wrapped in **s) are italicized.
        - Speech (text wrapped in ""s) is italicized and colorized.
        - Code blocks are stylized within black blocks for multiline code or white blocks for singleline.
        - Other text inside bubbles remains white.

**Pictures:**
![image](https://github.com/LostRuins/lite.koboldai.net/assets/32474602/31d87dcf-89b0-4116-bbe6-1b7084a84377)
- Markdown disabled:
![image](https://github.com/LostRuins/lite.koboldai.net/assets/32474602/d70ada70-42ba-4a09-b4f0-287e029b0693)
- Markdown enabled:
![image](https://github.com/LostRuins/lite.koboldai.net/assets/32474602/25b26cd8-84f0-4fa2-92c8-8d84daed7e23)


![image](https://github.com/LostRuins/lite.koboldai.net/assets/32474602/f8b0900c-3f72-4bee-a204-f4e63721d012)