### PR TITLE
Colorpicker improvements + Safari support for macOS + iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -8359,8 +8359,24 @@ Current version: 60
 			colorPicker.value = element.style[`${useBackground ? 'backgroundColor' : 'color'}`];
 			element.style.position = 'relative';
 			element.appendChild(colorPicker);
+			
+			// If we're on Safari browser and in iOS, we need some adjustments for the colorpickers to work.
+			// ..this happens because the clicks need to be directly done on the colorPicker for iOS in Safari.
+			if (/^((?!Chrome|Firefox).)*Safari/i.test(navigator.userAgent) && /iPhone|iPad|iPod/i.test(navigator.userAgent)) {
+				// Create a wrapper for the existing content. This will fix the offset slightly.
+				let contentWrapper = document.createElement('div');
+				contentWrapper.style.position = 'relative';
+				contentWrapper.style.zIndex = '0';
+				element.appendChild(contentWrapper);
+
+				// Finally, make the colorPicker directly clickable, and offset it slightly towards the text block.
+				colorPicker.style.zIndex = '1';
+				colorPicker.style.margin = '-20px';
+			}
+			else {
 				colorPicker.style.zIndex = '-1';
 				element.addEventListener('click', () => colorPicker.click());
+			}
 			
 			// Initialize the functionalities of the colorPicker
 			colorPicker.addEventListener('change', function() {

--- a/index.html
+++ b/index.html
@@ -8342,21 +8342,33 @@ Current version: 60
 				var obj = JSON.parse(jsonString);
 				for (let key in obj) { if (aestheticInstructUISettings.hasOwnProperty(key)) { aestheticInstructUISettings[key] = obj[key]; } }
 			}
-		}else{
-			//reset to defaults
-			localStorage.setItem((localmode?"e_":"")+'koboldLiteUICustomizationOptions', JSON.stringify(aestheticInstructUISettings, null, 2));
-		}
-		// Initialize text colorPicker and background color pickers. Text colorPicker should change the foreground, and background colorPicker should change the background.
+		}	// If persist session isn't toggled, reset to the default settings.
+		else { localStorage.setItem((localmode ? 'e_': '') + 'koboldLiteUICustomizationOptions', JSON.stringify(aestheticInstructUISettings, null, 2)); }
+
+		// Initialize foregroundColorPickers and backgroundColorPickers.
 		document.querySelectorAll('.enhancedTextColorPicker, .enhancedStandardColorPicker').forEach(element => {
-			element.addEventListener('click', (e) => {
-				let clrPicker = e.target.classList.contains('enhancedTextColorPicker') ? colorPicker : colorPicker_background;
-				clrPicker.clickedElement = e.target;
-				clrPicker.click();
+			// Create a fully transparent colorPicker for each element and initialize it as child of the textblock element.
+			// ..this happens because we want the colorPicker to open right below the element.
+			let useBackground = !element.classList.contains('enhancedTextColorPicker');
+			let colorPicker = document.createElement('input');
+			colorPicker.type = 'color';
+			colorPicker.style.opacity = '0';
+			colorPicker.style.position = 'absolute';
+			colorPicker.style.width = '100%';
+			colorPicker.style.height = '100%';
+			colorPicker.value = element.style[`${useBackground ? 'backgroundColor' : 'color'}`];
+			element.style.position = 'relative';
+			element.appendChild(colorPicker);
+				colorPicker.style.zIndex = '-1';
+				element.addEventListener('click', () => colorPicker.click());
+			
+			// Initialize the functionalities of the colorPicker
+			colorPicker.addEventListener('change', function() {
+				element.style[`${useBackground ? 'backgroundColor' : 'color'}`] = this.value;
+				refreshPreview();
 			});
 			element.addEventListener('mouseover', () => element.style.cursor = "pointer");
 		});
-		document.getElementById('colorPicker').addEventListener('change', 			 function() { this.clickedElement.style.color           = this.value; this.clickedElement = null; refreshPreview(); });
-		document.getElementById('colorPicker_background').addEventListener('change', function() { this.clickedElement.style.backgroundColor = this.value; this.clickedElement = null; refreshPreview(); });
 
 		// Initialize functionality for the margin & padding input fields.
 		document.querySelectorAll('.instruct-settings-input').forEach(element => {
@@ -8555,14 +8567,14 @@ Current version: 60
 		// We'll transform the input to a well-formatted HTML string.
 		let newbodystr = (input.startsWith(you) || input.startsWith(bot)) ? input : style('sys') + input;			// First, create the string we'll transform. Style system bubble if we should.
 		if (newbodystr.endsWith(bot)) { newbodystr = newbodystr.slice(0, -bot.length); }							// Reduce any unnecessary spaces or newlines. Trim empty replies if they exist.
-		newbodystr = replaceAll(newbodystr,you + '\n', you);
+		newbodystr = replaceAll(newbodystr, you + '\n', you);
 		newbodystr = replaceAll(newbodystr, bot + '\n', bot);
 		newbodystr = replaceAll(newbodystr, you + ' ', you);
-		newbodystr = replaceAll(newbodystr,bot + ' ', bot);
+		newbodystr = replaceAll(newbodystr, bot + ' ', bot);
 		newbodystr = replaceAll(newbodystr,'"', '&quot;');
-		newbodystr = replaceAll(newbodystr,you + '\n', you);
-		newbodystr = replaceAll(newbodystr,you, style('you'));
-		newbodystr = replaceAll(newbodystr,bot, style('AI'));
+		newbodystr = replaceAll(newbodystr, you + '\n', you);
+		newbodystr = replaceAll(newbodystr, you, style('you'));
+		newbodystr = replaceAll(newbodystr, bot, style('AI'));
 		newbodystr += contextDict.closeTag; 	// Style background of incoming and outgoing messages appropriately.
 		if (aestheticInstructUISettings.use_markdown) {																// If markdown is enabled, style the content of each bubble as well.
 			let internalHTMLparts = []; // We'll cache the embedded HTML parts here to keep them intact.
@@ -9402,7 +9414,6 @@ Current version: 60
 		</div>
 	</div>
 
-
 	<div class="popupcontainer flex hidden" id="workercontainer">
 		<div class="popupbg flex"></div>
 		<div class="workerpopup">
@@ -9711,8 +9722,6 @@ Current version: 60
 					<p>Style Preview</p>
 					<div id="aesthetic_text_preview" style="background-color: black; margin: 2px; text-align: left; word-wrap: break-word;"></div>
 				</div>
-				<input type="color" id="colorPicker" style="display: none;">
-				<input type="color" id="colorPicker_background" style="display: none;">
 				<input type="file" id="portraitFileInput" style="display:none" accept="image/*">
 			</div>
 		</div>


### PR DESCRIPTION
### Changelog:
Improved color pickers for Aesthetic Instruct Mode Customization UI, and added support for Safari.
- Colorpickers now pop up directly below the element whose color we're editing.
- Colorpickers now work on Safari for both macOS and iOS.