### PR TITLE
Add `Keep Memory and World Info` option to New Session

### DIFF
--- a/index.html
+++ b/index.html
@@ -7816,15 +7816,7 @@ Current version: 101
 		synchro_pending_stream = "";
 		waiting_for_autosummary = false;
 		last_reply_was_empty = false;
-		if (!keep_memory) current_memory = "";
-		if (!keep_memory) current_anote = "";
-		if (!keep_memory) current_wi = [];
 		pending_context_preinjection = "";
-		if (!keep_memory) extrastopseq = "";
-		if (!keep_memory) anote_strength = 320;
-		if (!keep_memory) wi_searchdepth = 0;
-		if (!keep_memory) wi_insertlocation = 0;
-		if (!keep_memory) current_anotetemplate = "[Author's note: <|>]";
 		document.getElementById("input_text").value = "";
 		document.getElementById("cht_inp").value = "";
 		chat_resize_input();
@@ -7833,9 +7825,20 @@ Current version: 101
 		localsettings.adventure_is_action = false;
 		prev_hl_chunk = null;
 		last_token_budget = "";
-		if (!keep_memory) last_known_filename = "saved_story.json";
 		groupchat_removals = [];
 		welcome = "";
+		last_known_filename = "saved_story.json";
+		if (!keep_memory)
+		{
+			current_memory = "";
+			current_anote = "";
+			current_wi = [];
+			extrastopseq = "";
+			anote_strength = 320;
+			wi_searchdepth = 0;
+			wi_insertlocation = 0;
+			current_anotetemplate = "[Author's note: <|>]";
+		}
 		render_gametext(save); //necessary to trigger an autosave to wipe out current story in case they exit browser after newgame.
 	}
 

--- a/index.html
+++ b/index.html
@@ -7649,7 +7649,7 @@ Current version: 101
 			selected_workers = [];
 			localsettings.opmode = 1;
 		}
-		restart_new_game();
+		restart_new_game(true, document.getElementById("keep_memory").checked);
 		hide_popups();
 	}
 
@@ -7802,7 +7802,7 @@ Current version: 101
 		horde_poll_nearly_completed = false;
 	}
 
-	function restart_new_game(save = true) {
+	function restart_new_game(save = true, keep_memory = false) {
 		idle_timer = 0;
 		gametext_arr = [];
 		redo_arr = [];
@@ -7816,15 +7816,15 @@ Current version: 101
 		synchro_pending_stream = "";
 		waiting_for_autosummary = false;
 		last_reply_was_empty = false;
-		current_memory = "";
-		current_anote = "";
-		current_wi = [];
+		if (!keep_memory) current_memory = "";
+		if (!keep_memory) current_anote = "";
+		if (!keep_memory) current_wi = [];
 		pending_context_preinjection = "";
-		extrastopseq = "";
-		anote_strength = 320;
-		wi_searchdepth = 0;
-		wi_insertlocation = 0;
-		current_anotetemplate = "[Author's note: <|>]";
+		if (!keep_memory) extrastopseq = "";
+		if (!keep_memory) anote_strength = 320;
+		if (!keep_memory) wi_searchdepth = 0;
+		if (!keep_memory) wi_insertlocation = 0;
+		if (!keep_memory) current_anotetemplate = "[Author's note: <|>]";
 		document.getElementById("input_text").value = "";
 		document.getElementById("cht_inp").value = "";
 		chat_resize_input();
@@ -7833,7 +7833,7 @@ Current version: 101
 		localsettings.adventure_is_action = false;
 		prev_hl_chunk = null;
 		last_token_budget = "";
-		last_known_filename = "saved_story.json";
+		if (!keep_memory) last_known_filename = "saved_story.json";
 		groupchat_removals = [];
 		welcome = "";
 		render_gametext(save); //necessary to trigger an autosave to wipe out current story in case they exit browser after newgame.
@@ -12004,7 +12004,18 @@ Current version: 101
 			</div>
 			<div class="aidgpopuplistheader anotelabel">
 				Unsaved data will be lost.<br><br>
-				<div class="" title="If disabled, brings you back to the start page"><span style=" vertical-align: middle;">Keep AI Selected? </span> <input type="checkbox" id="keep_ai_selected" style=" vertical-align: top;" checked></div>
+				<div>
+					<div style="vertical-align: middle;">
+						<div title="If disabled, brings you back to the start page">
+							<span>Keep AI Selected? </span>
+							<input type="checkbox" id="keep_ai_selected" style=" vertical-align: top;" checked>
+						</div>
+						<div>
+							<span>Keep Memory and World Info? </span>
+							<input type="checkbox" id="keep_memory" style=" vertical-align: top;">
+						</div>
+					</div>
+				</div>
 				<br>
 			</div>
 			<div class="popupfooter">


### PR DESCRIPTION
### Motivation

Switching on edit mode, selecting everything, and then deleting, whenever I want to restart story generation from the beginning, or forgetting to do that and losing my just made edits to Memory (or World Info), has gotten tedious enough that I broke down and implemented an option to keep them.

### Changes

* Adds a `Keep Memory and World Info` checkbox box to the new session dialog, defaulting to unchecked.
* Updates `restart_newgame` with an optional `keep_memory` argument, defaulting to false.
* Call `restart_newgame` with `keep_memory` set from the checkbox selection when the New Session dialog is confirmed.

### Possible Problems/Concerns

* Maybe it should be `clear_memory` for the function parameter, and have the not in the call?
* I've set the default to not keep memory, so you get same behaviour as the current version by default. However maybe keeping should be the default? It's what I want to do most of the time.
* Tested connecting locally to Koboldcpp, rather than Horde.

### Screenshot

![return_memory_option](https://github.com/LostRuins/lite.koboldai.net/assets/121311569/bdb3bbaa-35db-4f10-93b7-940fef5fd22e)
