### PR TITLE
XTTS config fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3398,7 +3398,8 @@ Current version: 108
 		instruct_has_markdown: true,
 		placeholder_tags: true,
 		persist_session: true,
-		speech_synth: 0, //0 is disabled, 100 is xtts
+		speech_synth: 0, //0 is disabled, 1000 is xtts
+		xtts_voice: "female",
 		beep_on: false,
 		notify_on: false,
 		narrate_both_sides: false,
@@ -7440,7 +7441,7 @@ Current version: 108
 		} else {
 			console.log("No speech synth available");
 		}
-		ttshtml += "<option value=\"100\">XTTS API Server</option>";
+		ttshtml += "<option value=\"1000\">XTTS API Server</option>";
 		document.getElementById("ttsselect").innerHTML = ttshtml;
 		document.getElementById("ttsselect").value = localsettings.speech_synth;
 		toggle_tts_mode();
@@ -8372,8 +8373,18 @@ Current version: 108
 			popup_manual_image();
 		}
 	}
+		
+	// Check for XTTS in previous session or if set in initial variables
+	if(localsettings.speech_synth==1000)
+	{
+		xtts_is_connected = false;
+		fetch_xtts_voices(true);
+	}
+	else
+	{
+		xtts_is_connected = false;
+	}
 
-	var xtts_is_connected = false;
 	function fetch_xtts_voices(silent)
 	{
 		if(!xtts_is_connected)
@@ -8389,6 +8400,7 @@ Current version: 108
 						selectionhtml += `<option value="` + data[i] + `">`+data[i]+`</option>`;
 					}
 					dropdown.innerHTML = selectionhtml;
+					document.getElementById("xtts_voices").value = localsettings.xtts_voice;
 					xtts_is_connected = true;
 			}).catch((error) => {
 				xtts_is_connected = false;
@@ -8402,7 +8414,7 @@ Current version: 108
 
 	function toggle_tts_mode()
 	{
-		if(document.getElementById("ttsselect").value==100)
+		if(document.getElementById("ttsselect").value==1000)
 		{
 			document.getElementById("xtts_container").classList.remove("hidden");
 			fetch_xtts_voices(true);
@@ -8432,14 +8444,15 @@ Current version: 108
 	}
 	function tts_speak(text)
 	{
-		if(localsettings.speech_synth==100) //xtts api server
+		if(localsettings.speech_synth==1000) //xtts api server
 		{
 			if(xtts_is_connected)
 			{
+				localsettings.xtts_voice = document.getElementById("xtts_voices").value;
 				const audioContext = new (window.AudioContext || window.webkitAudioContext)();
 				let xtts_payload = {
 					"text": text,
-					"speaker_wav": document.getElementById("xtts_voices").value,
+					"speaker_wav": localsettings.xtts_voice, //document.getElementById("xtts_voices").value,
 					"language": "EN"
 				};
 

--- a/index.html
+++ b/index.html
@@ -3301,6 +3301,8 @@ Current version: 108
 	const default_a1111_base = "http://localhost:7860";
 	const default_xtts_base = " http://localhost:8020";
 
+	const XTTS_ID = 1000;
+
 	//all configurable globals
 	var perfdata = null; //if it's null, we are not connected
 	var models_data = [];
@@ -3399,7 +3401,7 @@ Current version: 108
 		placeholder_tags: true,
 		persist_session: true,
 		speech_synth: 0, //0 is disabled, 1000 is xtts
-		xtts_voice: "female",
+		xtts_voice: "female_calm",
 		beep_on: false,
 		notify_on: false,
 		narrate_both_sides: false,
@@ -3922,6 +3924,15 @@ Current version: 108
 		{
 			fetch_image_models();
 		}
+		if(localsettings.speech_synth==XTTS_ID)
+		{
+			fetch_xtts_voices(true);
+		}
+		if(localsettings.generate_images_mode==2)
+		{
+			connect_to_a1111(true);
+		}
+
 		if(!initial_fetched_kudos && localsettings.my_api_key!=defaultsettings.my_api_key)
 		{
 			document.getElementById("apikey").value = localsettings.my_api_key;
@@ -7633,6 +7644,7 @@ Current version: 108
 		localsettings.miro_eta = document.getElementById("miro_eta").value;
 
 		localsettings.speech_synth = document.getElementById("ttsselect").value;
+		localsettings.xtts_voice = document.getElementById("xtts_voices").value;
 		localsettings.beep_on = (document.getElementById("beep_on").checked?true:false);
 		localsettings.notify_on = (document.getElementById("notify_on").checked?true:false);
 		localsettings.narrate_both_sides = (document.getElementById("narrate_both_sides").checked?true:false);
@@ -8375,18 +8387,8 @@ Current version: 108
 			popup_manual_image();
 		}
 	}
-		
-	// Check for XTTS in previous session or if set in initial variables
-	if(localsettings.speech_synth==1000)
-	{
-		xtts_is_connected = false;
-		fetch_xtts_voices(true);
-	}
-	else
-	{
-		xtts_is_connected = false;
-	}
 
+	var xtts_is_connected = false;
 	function fetch_xtts_voices(silent)
 	{
 		if(!xtts_is_connected)
@@ -8399,11 +8401,13 @@ Current version: 108
 				let dropdown = document.getElementById("xtts_voices");
 					let selectionhtml = ``;
 					for (var i = 0; i < data.length; ++i) {
-						selectionhtml += `<option value="` + data[i] + `">`+data[i]+`</option>`;
+						// Check for XTTS voices if set
+						let sel = (localsettings.xtts_voice!=""&&localsettings.xtts_voice==data[i]);
+						selectionhtml += `<option value="` + data[i] + `"`+(sel?" selected":"")+`>`+data[i]+`</option>`;
 					}
 					dropdown.innerHTML = selectionhtml;
-					document.getElementById("xtts_voices").value = localsettings.xtts_voice;
 					xtts_is_connected = true;
+
 			}).catch((error) => {
 				xtts_is_connected = false;
 				if(!silent)
@@ -8416,7 +8420,7 @@ Current version: 108
 
 	function toggle_tts_mode()
 	{
-		if(document.getElementById("ttsselect").value==1000)
+		if(document.getElementById("ttsselect").value==XTTS_ID)
 		{
 			document.getElementById("xtts_container").classList.remove("hidden");
 			fetch_xtts_voices(true);
@@ -8446,15 +8450,14 @@ Current version: 108
 	}
 	function tts_speak(text)
 	{
-		if(localsettings.speech_synth==1000) //xtts api server
+		if(localsettings.speech_synth==XTTS_ID) //xtts api server
 		{
 			if(xtts_is_connected)
 			{
-				localsettings.xtts_voice = document.getElementById("xtts_voices").value;
 				const audioContext = new (window.AudioContext || window.webkitAudioContext)();
 				let xtts_payload = {
 					"text": text,
-					"speaker_wav": localsettings.xtts_voice, //document.getElementById("xtts_voices").value,
+					"speaker_wav": document.getElementById("xtts_voices").value,
 					"language": "EN"
 				};
 


### PR DESCRIPTION
Fixes XTTS setting being overwritten if there are more than 100 TTS voices available on the system.

Stores your xtts_speaker setting between multiple sessions

Setting const default_xtts_base = " http://localhost:8020"; to your endpoint and changing speech_synth: 0, //0 is disabled, 1000 is xtts to 1000 will have the client auto reconnect to XTTS with your prior settings on refresh.