### PR TITLE
Add media query styles for printing

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,6 +265,25 @@ Current version: 110
 			resize: vertical;
 		}
 
+		@media print {
+			#inputrow, .cht_inp_hold_outer {
+				display: none;
+			}
+			#lastreq, .lastreq, #lastreq2 {
+				display: none;
+			}
+			#actionmenu, #actionmenu2 {
+				display: none;
+			}
+			#topmenu {
+				display: none;
+			}
+			#gametext, #gamescreen, .chat_msg_history, .aesthetic_viewport_height {
+				display: inline;
+				height: auto;
+			}
+		}
+
 		#btnmode_chat, #btnmode_adventure {
 			width: 100%;
 			height: 100%;


### PR DESCRIPTION
## Motivation

Printing in story mode still includes a lot the UI, and the main text doesn't seem to flow beyond the first page in non-aesthetic mode (at least for me).

This should fix that for all modes.

## Changes

- Hides top menu when printing.
- Hides input row and chat input holder when printing
- Hides bottom info/status line when printing.
- Hides action menu (if displayed) when printing.
- Allows main text/chat history to flow across multiple pages when printing.

## Possible Problems/Concern

- I've targeted this PR at `dev` branch, I'm not sure whether that is how you want things or it should got to `main`.
