### PR TITLE
Fix anote/stopseq line drop

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@ Current version: 113
 		.anotetempbox
 		{
 			display: inline;
-			width: calc(100% - 98px);
+			width: 100%;
 		}
 		.anotetempscale
 		{
@@ -308,7 +308,7 @@ Current version: 113
 		.stopseqbox
 		{
 			display: inline;
-			width: calc(100% - 110px);
+			width: 100%;
 		}
 
 		#popuptitlebar {
@@ -13936,6 +13936,7 @@ Current version: 113
 				</span>
 			</div>
 
+			<div style="display: flex; column-gap: 4px;">
 			<input class="form-control anotetempbox" type="text"
 				placeholder="(the &lt;|&gt; will be replaced with the Author's Note text)" value="" id="anotetemplate">
 				<select style="padding:4px;" class="anotetempscale form-control" id="anote_strength">
@@ -13944,13 +13945,15 @@ Current version: 113
 					<option value="160">Strong</option>
 					<option value="0">Immediate</option>
 				</select>
-			<br><br>
+			</div>
+			<br>
 			<div class="justifyleft settinglabel">Extra Stopping Sequences <span class="helpicon">?<span
 				class="helptext">Triggers the text generator to stop generating early if this sequence appears, in addition to default stop sequences. If you want multiple sequences, separate them with the following delimiter: ||$||</span></span></div>
 				<div class="color_red hidden" id="noextrastopseq">Stop Sequences may be unavailable.</div>
+				<div style="display: flex; column-gap: 4px; margin-bottom: 4px;">
 				<input class="form-control stopseqbox" type="text" placeholder="None" value="" id="extrastopseq">
-				<button type="button" class="btn btn-primary" style="width:104px;padding:6px 6px;margin-bottom: 4px;" id="btnlogitbias" onclick="set_logit_bias()">Logit Biases</button>
-			<br>
+				<button type="button" class="btn btn-primary" style="width:104px;padding:6px 6px;" id="btnlogitbias" onclick="set_logit_bias()">Logit Biases</button>
+			</div>
 			<div class="popupfooter">
 				<button type="button" class="btn btn-primary" onclick="confirm_memory()">OK</button>
 				<button type="button" class="btn btn-primary" onclick="hide_popups()">Cancel</button>


### PR DESCRIPTION
Fixed line dropping of memory menu elements in Android Opera.

Before
<img src="https://github.com/LostRuins/lite.koboldai.net/assets/18329136/75793192-e479-40cf-b642-7a9f8d413899" width="250">

After
<img src="https://github.com/LostRuins/lite.koboldai.net/assets/18329136/aa60b80a-764d-455c-9e1f-8720121d383e" width="250">
