### PR TITLE
Improved identification of character names.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10267,7 +10267,8 @@ Current version: 141
 				}
 
 				//examine context to try to determine if there's an existing botname
-				var othernamesregex = new RegExp("\n(?!" + localsettings.chatname + ").+?\: ", "gi");
+				var othernamesregex = new RegExp("\n(" + localsettings.chatopponent.split("||$||").join("|") + ")\: ", "gi");
+
 				var tempfullsearchable = current_memory + current_anote + truncated_context;
 				var foundopponent = tempfullsearchable.match(othernamesregex);
 
@@ -13072,9 +13073,9 @@ Current version: 141
 				let m_name = "\n" + localsettings.chatname + ": ";
 
 				//match anything that is NOT us, ie. opponents
-				var regex = new RegExp("\n(?!" + localsettings.chatname + ").+?\: ", "gi");
+				var othernamesregex = new RegExp("\n(" + localsettings.chatopponent.split("||$||").join("|") + ")\: ", "gi");
 				let colormap = {}, colidx = 0;
-				fulltxt = fulltxt.replace(regex, function (m) {
+				fulltxt = fulltxt.replace(othernamesregex, function (m) {
 					let oname = escapeHtml(m);
 					let onametrim = oname.trim();
 					if(colormap[onametrim]==null)
@@ -13349,8 +13350,7 @@ Current version: 141
 		let newbodystr = "";
 		let myturnchat = false; //who is currently speaking?
 
-
-		var othernamesregex = new RegExp("(?!" + localsettings.chatname + ").+?\: ", "gi");
+		var othernamesregex = new RegExp("(" + localsettings.chatopponent.split("||$||").join("|") + ")\: ", "gi");
 
 		//a quick fix that adds a newline if there's none before opponent chat and a picture
 		var othernamesregexreplace = new RegExp("\\|[d|p]\\|>(?!" + localsettings.chatname + ").+?\\: ", "gi");
@@ -14526,8 +14526,7 @@ Current version: 141
 			var mynameregex = new RegExp("\n(" + localsettings.chatname + ")\: ", "gi");
 			var mynameregex2 = new RegExp("(" + localsettings.chatname + ")\: ", "gi");
 			var mynameregex3 = new RegExp("\n(" + localsettings.chatname + ") ", "gi");
-			var othernamesregex = new RegExp("\n(?!" + localsettings.chatname + ").+?\: ", "gi");
-			//var othernamesregex2 = new RegExp("(?!" + localsettings.chatname + ").+?\: ", "gi");
+			var othernamesregex = new RegExp("\n(" + localsettings.chatopponent.split("||$||").join("|") + ")\: ", "gi");
 			input = input.replaceAll(mynameregex, '{{userplaceholder}}');
 			input = input.replaceAll(mynameregex2, '{{userplaceholder}}');
 			input = input.replaceAll(mynameregex3, '{{userplaceholder}}');


### PR DESCRIPTION
## Motivation
This aims to address https://github.com/LostRuins/koboldcpp/issues/867, where certain lines of text are misidentified as character names.

## Changes
Updated the regex expressions responsible for identifying character names to make sure that only listed characters (stored in `localsettings.chatopponent`) are matched.

The logic for this is done in 4 places in `index.html`. I renamed the variable names of one of the regex expressions to make them more searchable, but ideally this should be delegated to a function to prevent code duplication and inconsistencies.

## To review before merging
- ~~Line 13353 (used for Messenger UI in Chat mode) does not have a `\n` before the opening bracket, but this seems inconsistent with the other regex expressions, so I added it.~~
  - Apparently, if you add a `\n` in front, like all other cases, it fails to format the character in Messenger UI.
- Does line 13356 ([permalink](https://github.com/LostRuins/lite.koboldai.net/blob/ef21a6f82903221771bfa933c9c752b03f6067d6/index.html#L13356)) need to change as well?

## Potential issues
This will break characters which are not added to the characters list. This would affect users who added characters then deleted them, or for those who manually write custom characters into the story. However, I'm not sure if any users fall into these categories, and it seems like it has always been the intention to only search for added characters.

## Scope of impact
It should only affect Chat mode (`localsettings.opmode == 3`).