### PR TITLE
fix any name matching in aesthetic theme chat mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -17304,19 +17304,22 @@ Current version indicated by LITEVER below.
 				othernamesregex = new RegExp("(" + namePattern + "): ", "gi");
 			}
 
-			input = input.replaceAll(mynameregex, '{{userplaceholder}}');
-			input = input.replaceAll(mynameregex2, '{{userplaceholder}}');
-			input = input.replaceAll(mynameregex3, '{{userplaceholder}}');
 			if(as.show_chat_names)
 			{
-				input = input.replaceAll("{{userplaceholder}}", `{{userplaceholder}}<p class='aui_nametag'>`+escapeHtml(localsettings.chatname)+`</p>`);
 				input = input.replaceAll(othernamesregex, function(match) {
 					return "{{botplaceholder}}<p class='aui_nametag'>" + escapeHtml(match.substring(0,match.length-2).trim()) + "</p>";
 				});
+				input = input.replaceAll(mynameregex, '{{userplaceholder}}');
+				input = input.replaceAll(mynameregex2, '{{userplaceholder}}');
+				input = input.replaceAll(mynameregex3, '{{userplaceholder}}');
+				input = input.replaceAll("{{userplaceholder}}", `{{userplaceholder}}<p class='aui_nametag'>`+escapeHtml(localsettings.chatname)+`</p>`);
 			}
 			else
 			{
 				input = input.replaceAll(othernamesregex, "{{botplaceholder}}");
+				input = input.replaceAll(mynameregex, '{{userplaceholder}}');
+				input = input.replaceAll(mynameregex2, '{{userplaceholder}}');
+				input = input.replaceAll(mynameregex3, '{{userplaceholder}}');
 			}
 
 			you = "{{userplaceholder}}";


### PR DESCRIPTION
### Description
Some inputs get rendered incorrectly under the Aesthetic Theme in the Chat Mode.
The problem manifests itself when the `Chat Match Any Name` option is on, the AI's message contains a line break and the following User's message contains a colon character (:) followed by a space on the first line of the message.
Both the standalone KoboldAI Lite and the one bundled with KoboldCPP currently exhibit this problem.
### Cause of the problem
As I understand it, the problem is caused by the User's name getting replaced in the input first, which causes the check `(?!" + localsettings.chatname + ")` inside of `othernamesregex` no longer to work.
### Proposed solution
I have tried reordering the replacements, so that `othernamesregex` was applied before the replacement of the User's name. The fix seems to be working, and so far I haven't encountered problems.
### Screenshot of the the problem
![20240918155203929426054](https://github.com/user-attachments/assets/402db283-deef-44ec-9e3a-c07c6ea25f55)
![20240918155157082793538](https://github.com/user-attachments/assets/1c737e82-5ece-47c1-a737-0b5d0752bb54)
