### PR TITLE
refresh: Corpo-UI light visual tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -2233,6 +2233,9 @@ Current version indicated by LITEVER below.
     	background-position: 8px;
 		background-size: 24px;
 	}
+	.corpo_leftpanel_btn:active {
+		transform: translateY(1px);
+	}	
 	body.darkmode .corpo_leftpanel_btn:hover
 	{
 		color: #76a8ee;		

--- a/index.html
+++ b/index.html
@@ -168,10 +168,13 @@ Current version indicated by LITEVER below.
 		}
 
 		#topmenu {
-			background-color: #757575;
+			background-image: linear-gradient(90deg, #2e63ac, #2e63ac, #2e4fac, #2e4fac);
 			padding: 8px;
 			display: flex;
 			line-height: normal;
+
+			outline: 3px solid #2e63ac;
+			outline-offset: -3px;
 		}
 
 		body.connected #topmenu {
@@ -185,6 +188,7 @@ Current version indicated by LITEVER below.
 
 		#navbar {
 			margin: 0px;
+			margin-left: -6px;
 		}
 
 		#navbar li {
@@ -199,8 +203,9 @@ Current version indicated by LITEVER below.
 		}
 
 		#navbar li>a {
-			color: #ffffff;
+			color: #f2f2f2;
 			font-weight: bold;
+			text-shadow: rgb(33, 33, 33);
 		}
 
 		.settingsmenu {
@@ -1003,12 +1008,12 @@ Current version indicated by LITEVER below.
 
 		.navbar .navbar-nav .nav-link:hover {
 			border-radius: 5px;
-			background-color: #bababa;
+			background-color: #4db4ea;
 		}
 
 		body.connected .navbar .navbar-nav .nav-link:hover,
 		.navbar .navbar-nav .nav-link.always-available:hover {
-			background-color: #98bcdb;
+			background-color: #4db4ea;
 		}
 
 		body .navbar .navbar-nav .dropdown-item.always-available {
@@ -1021,7 +1026,7 @@ Current version indicated by LITEVER below.
 
 		.navbar .navbar-nav .nav-link:focus {
 			border-radius: 5px;
-			background-color: #bababa;
+			background-color: #4db4ea;
 		}
 
 		body.connected .navbar .navbar-nav .nav-link:focus,
@@ -2028,11 +2033,12 @@ Current version indicated by LITEVER below.
 		{
 			font-size: 16px;
 			line-height: 26px;
-		}
+		}	
 		.corpostyleinner
 		{
 			padding-left: 6px;
 			padding-right: 6px;
+			margin-top: 0px;			
 		}
 		.corpostyleitem
 		{
@@ -2183,8 +2189,8 @@ Current version indicated by LITEVER below.
 
 	.corpoleftpanel
 	{
-		width:240px;
-		background-color: #f4f4f4;
+		width:256px;
+		background-color: #e2e5e6;
 		padding-left: 8px;
 		padding-right: 8px;
 		transition: transform 0.3s ease;
@@ -2200,12 +2206,13 @@ Current version indicated by LITEVER below.
 	{
 		display: flex;
 		flex-direction: column;
+		margin-top: 16px;
 		padding: 2px;
 	}
 	.corpo_leftpanel_btn
 	{
-		padding: 6px;
-		margin: 4px;
+		padding: 4px;
+		margin: 2px;
 		background: #f4f4f400;
 		border:none;
 		border-radius: 8px;
@@ -2218,15 +2225,17 @@ Current version indicated by LITEVER below.
     	text-overflow: ellipsis;
 		display: inline-block;
 		white-space: nowrap;
+		user-select: none;
 	}
 	.corpo_leftpanel_btn:hover {
-		background: #dddddd;
+		background: #9dcef5;
 		background-repeat: no-repeat;
     	background-position: 8px;
 		background-size: 24px;
 	}
 	body.darkmode .corpo_leftpanel_btn:hover
 	{
+		color: #76a8ee;		
 		background: #454545;
 		background-repeat: no-repeat;
     	background-position: 8px;
@@ -2279,6 +2288,11 @@ Current version indicated by LITEVER below.
 	}
 	@media (max-width: 768px) {
 
+		.corpostylemain
+		{
+			margin-top: 0px;
+		}
+
 		.corpoleftpanel {
 			position: fixed;
 			left: 0;
@@ -2306,7 +2320,7 @@ Current version indicated by LITEVER below.
 		display: flex;
 		justify-content: center;
 		align-items: center;
-		height: 60vh;
+		height: 75vh;
 		flex-direction: column;
 		text-align: center;
 	}
@@ -2321,12 +2335,13 @@ Current version indicated by LITEVER below.
 		overflow-y: auto;
 		padding-left: 2px;
 		padding-right: 2px;
+		margin-top: 12px;
 	}
 	.corpostyleinner
 	{
 		max-width: 860px;
 		margin-left: auto;
-    	margin-right: auto;
+    	margin-right: auto;		
 		padding-left: 8px;
 		padding-right: 8px;
 	}
@@ -10834,11 +10849,14 @@ Current version indicated by LITEVER below.
 		}
 
 	}
-
+	
 	function simplemodexample()
 	{
-		let simplemodscript = `// This mod changes your top menu to yellow color, then displays the current temperature setting as a popup\n\n`+
-		`document.getElementById("topmenu").style.backgroundColor = 'yellow';\nalert("Congrats, your top menu turned yellow. Also, your temperature was " + localsettings.temperature);`;
+		let simplemodscript = `// This mod changes your top menu to yellow color, then displays the current temperature setting as a popup`
+			+`\ndocument.getElementById("topmenu").style.backgroundImage = 'linear-gradient(90deg, #daa121, #daa121, #ac7a2e, #ac7a2e)';`
+			+`\ndocument.getElementById("topmenu").style.outline = '3px solid #daa121';`
+			+"\n"
+			+`alert("Congrats, your top menu turned yellow. Also, your temperature was " + localsettings.temperature);`;
 		document.getElementById("inputboxcontainerinputarea").value = simplemodscript;
 	}
 	function apply_user_mod()
@@ -16067,7 +16085,8 @@ Current version indicated by LITEVER below.
 		<div onclick="btn_memory()" class="corpo_leftpanel_btn" type="button" style="background-image: var(--img_gear); padding-left: 44px;">Context</div>
 		<div onclick="btn_editmode()" class="corpo_leftpanel_btn" type="button" style="background-image: var(--img_corpo_edit); padding-left: 44px;">Raw Editor</div>
 		<div onclick="update_toggle_lightmode(true)" class="corpo_leftpanel_btn" type="button" style="background-image: var(--img_corpo_theme); padding-left: 44px;">Light / Dark Theme</div>
-		<div style="padding:2px;font-size:14px;margin-left:8px;font-weight:600;line-height:1.1;margin-top:20px">Quick Slot Load</div>
+		<div style="padding:2px;font-size:14px;margin-left:8px;font-weight:600;line-height:1.1;margin-top:22px">Quick Slot Load</div>
+		<hr style="margin-top:4px;margin-bottom:6px" />
 		`;
 
 		for(let i=0;i<SAVE_SLOTS;++i)

--- a/index.html
+++ b/index.html
@@ -168,13 +168,10 @@ Current version indicated by LITEVER below.
 		}
 
 		#topmenu {
-			background-image: linear-gradient(90deg, #2e63ac, #2e63ac, #2e4fac, #2e4fac);
+			background-color: #757575;
 			padding: 8px;
 			display: flex;
 			line-height: normal;
-
-			outline: 3px solid #2e63ac;
-			outline-offset: -3px;
 		}
 
 		body.connected #topmenu {
@@ -2033,12 +2030,12 @@ Current version indicated by LITEVER below.
 		{
 			font-size: 16px;
 			line-height: 26px;
-		}	
+		}
 		.corpostyleinner
 		{
 			padding-left: 6px;
 			padding-right: 6px;
-			margin-top: 0px;			
+			margin-top: 0px;
 		}
 		.corpostyleitem
 		{
@@ -2235,10 +2232,10 @@ Current version indicated by LITEVER below.
 	}
 	.corpo_leftpanel_btn:active {
 		transform: translateY(1px);
-	}	
+	}
 	body.darkmode .corpo_leftpanel_btn:hover
 	{
-		color: #76a8ee;		
+		color: #76a8ee;
 		background: #454545;
 		background-repeat: no-repeat;
     	background-position: 8px;
@@ -2344,7 +2341,7 @@ Current version indicated by LITEVER below.
 	{
 		max-width: 860px;
 		margin-left: auto;
-    	margin-right: auto;		
+    	margin-right: auto;
 		padding-left: 8px;
 		padding-right: 8px;
 	}
@@ -10852,10 +10849,10 @@ Current version indicated by LITEVER below.
 		}
 
 	}
-	
+
 	function simplemodexample()
 	{
-		let simplemodscript = `// This mod changes your top menu to yellow color, then displays the current temperature setting as a popup`
+		let simplemodscript = `// This mod changes your top menu to a yellow gradient, then displays the current temperature setting as a popup\n`
 			+`\ndocument.getElementById("topmenu").style.backgroundImage = 'linear-gradient(90deg, #daa121, #daa121, #ac7a2e, #ac7a2e)';`
 			+`\ndocument.getElementById("topmenu").style.outline = '3px solid #daa121';`
 			+"\n"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ff9170fe-2306-43ce-b0a1-101afe2786f6)

I tweaked the positions of some of the elements in the corpo style and tried to give more pleasing colouring to various elements. 
I will look at the other styles. I think they could be brought up at the same level of visual coherence while keeping it layout-wise the same. Some of the changes are likely to reflect in other styles, due to shared elements.

*even the user mod example was updated.
