### PR TITLE
Update for Mistral V7

### DIFF
--- a/index.html
+++ b/index.html
@@ -4717,6 +4717,13 @@ Current version indicated by LITEVER below.
 		"user":"</s>[INST]",
 		"assistant":"[/INST]",
 		"system":"",
+	},
+	{
+		"id":15,
+		"name":"Mistral V7",
+		"user":"</s>[INST]",
+		"assistant":"[/INST]",
+		"system":"",
 	}
 	];
 

--- a/index.html
+++ b/index.html
@@ -4723,7 +4723,7 @@ Current version indicated by LITEVER below.
 		"name":"Mistral V7",
 		"user":"</s>[INST]",
 		"assistant":"[/INST]",
-		"system":"",
+		"system":"[SYSTEM_PROMPT]", //how do we do for the end of system prompt?
 	}
 	];
 


### PR DESCRIPTION
Noticed something, by default there is no BOS being prepended? since the templates that are here suppose no BOS is prepended by default, may need to be changed.