### PR TITLE
Fix char spec v2 embedded WI import

### DIFF
--- a/index.html
+++ b/index.html
@@ -7425,6 +7425,10 @@ Current version indicated by LITEVER below.
 				{
 					current_wi = load_tavern_wi(obj.character_book,chatopponent,myname);
 				}
+				else if (obj.data && obj.data.character_book && obj.data.character_book.entries && obj.data.character_book.entries.length > 0)
+				{
+					current_wi = load_tavern_wi(obj.data.character_book, chatopponent, myname);
+				}
 				else if(obj.entries && obj.entries.length>0)
 				{
 					current_wi = load_agnai_wi(obj,chatopponent,myname);
@@ -7614,10 +7618,14 @@ Current version indicated by LITEVER below.
 			temp_scenario.memory = combinedmem;
 
 			//since cai format has no wi, try to grab it from tavern format
+			let myname = ((localsettings.chatname && localsettings.chatname!="")?localsettings.chatname:"User");
 			if(obj.character_book && obj.character_book.entries && obj.character_book.entries.length>0)
 			{
-				let myname = ((localsettings.chatname && localsettings.chatname!="")?localsettings.chatname:"User");
 				temp_scenario.worldinfo = load_tavern_wi(obj.character_book,chatopponent,myname);
+			}
+			else if (obj.data && obj.data.character_book && obj.data.character_book.entries && obj.data.character_book.entries.length > 0)
+			{
+				temp_scenario.worldinfo = load_tavern_wi(obj.data.character_book, chatopponent, myname);
 			}
 			preview_temp_scenario();
 		}


### PR DESCRIPTION
As per the [v2 spec](https://github.com/malfoyslastname/character-card-spec-v2?tab=readme-ov-file#proposed-fields), `character_book` should be nested into the `data` object.