### PR TITLE
Feature: Randomizing macros {{random:...}}, {{pick:...}}, {{roll:...}}

### DIFF
--- a/index.html
+++ b/index.html
@@ -3256,7 +3256,7 @@ Current version indicated by LITEVER below.
 		instruct_has_latex: true,
 		placeholder_tags: true,
 		render_special_tags: false,
-		inject_randomness_seed: 1115215124,
+		inject_randomness_seed: -1,
 		request_logprobs: false,
 		persist_session: true,
 		speech_synth: 0, //0 is disabled, 1000 is xtts
@@ -3589,12 +3589,12 @@ Current version indicated by LITEVER below.
 		//truncate to first 3 bytes
 		return hsh.substring(0, 6);
 	};
-	function basic_LCG(seed) { //simple RNG for reproducible dicerolls
+	function basic_lcg(seed) { //simple RNG for reproducible dicerolls
 		var m = 2**35 - 31;
 		var a = 185852;
 		var s = seed % m;
 		return function () {
-			return (s = s * a % m) / m
+			return ((s = s * a % m) / m);
 		}
 	}
 	function import_props_into_object(existingObj, objToImport) { //import new fields from one object into another while preserving exsting
@@ -4328,13 +4328,13 @@ Current version indicated by LITEVER below.
 		text = text.replace(/\{\{\[SYSTEM\]\}\}/g, "").replace(/\{\{\[SYSTEM_END\]\}\}/g, "");
 		return text;
 	}
-	function replace_search_placeholders(text,isstorage=false) {
+	function replace_search_placeholders(text) {
 
 		// Remove any instruct tags as needed to ensure a more accurate search
 		text = remove_all_instruct_tags(text);
 
 		// Replace {{user}} and other placeholders
-		text = replace_placeholders(text,false,false,!isstorage);
+		text = replace_placeholders(text,false,false,false);
 
 		return text;
 	}
@@ -4383,64 +4383,85 @@ Current version indicated by LITEVER below.
 			}
 		}
 
-		if(localsettings.inject_randomness_seed!=-1)
+		if(localsettings.inject_randomness_seed>0)
 		{
 			// define helper functions
 			let dicenotation = function(formula,seed=0){
-				RNG = seed ? basic_LCG(seed) : Math.random;
 				formula = formula.trim();
-				if (/^\d+$/.test(formula)){ formula = "1d${formula}"; }
+				if (/^\d+$/.test(formula)) { formula = `1d${formula}`; }
 				const pieces = formula.match(/^(\d+)?d(\d+)([x*\u00D7]\d*\.?\d+)?([+-]\d*\.?\d+)?$/i);
 				if (!pieces) {
+					return ""; //if the dice test fails we still need to return the original unswapped content!
+				}
+				let RNG = seed ? basic_lcg(seed) : Math.random;
+				let numDice = parseInt(pieces[1]) || 1;
+				let dieSides = parseInt(pieces[2]);
+				if (isNaN(numDice) || isNaN(dieSides) || dieSides < 0 || dieSides > 99999) { //dice above 99999 cause extreme slowdown
+					console.warn("Avoid potential dice issues");
 					return "";
 				}
-				let total = (pieces[1]-0)||1;
-				for (let i=0; i < ((pieces[1]-0)||1); ++i) {
-					total += Math.floor(RNG()*pieces[2]);
+				let total = 0;
+				for (let i = 0; i < numDice; ++i) {
+					total += Math.floor(RNG() * dieSides) + 1; // Standard dice rolls are 1-based
 				}
 				total *= pieces[3] ? parseFloat(pieces[3].substring(1)) : 1;
 				total += pieces[4] ? parseFloat(pieces[4]) : 0;
 				return String(total);
 			}
 			let pickfromlist = function(listString,seed=0){
-				const list = listString.includes('::') ? listString.split('::') : listString.replace(/\\,/g, '{{COMMA}}').split(',').map(item => item.trim().replace(/{{COMMA}}/g, ','));
-				return (list.length===0 ? '' : list[Math.floor((seed ? seed/(2**24) : Math.random())*list.length)]);
+				let RNG = seed ? basic_lcg(seed) : Math.random;
+				const list = listString.includes('::') ? listString.split('::') : listString.replace(/\\,/g, '%%COMMA%%').split(',').map(item => item.trim().replace(/%%COMMA%%/g, ','));
+				return (list.length===0 ? '' : list[Math.floor(RNG()*list.length)]);
 			}
 
-			if(!isgametext)
+			//don't waste time if we dont have any such tags
+			let lowerinputtxt = inputtxt.toLowerCase();
+			if (lowerinputtxt.includes("\{\{pick") || lowerinputtxt.includes("\{\{random") || lowerinputtxt.includes("\{\{roll"))
 			{
-	 			inputtxt = inputtxt.replace(/{{roll\s?:?:?([^}]+)}}/gi, function (m,matchValue) {
-					return dicenotation(matchValue, 0);
-				});
-				inputtxt = inputtxt.replace(/{{random\s?:?:?([^}]+)}}/gi, function (m,listString) {
-					return pickfromlist(listString,0);
-				});
-				stablereg = /{{(?:pick)\s?:?:?([^}]+)}}/gi;
-			}
-			else
-			{
-				stablereg = /{{(?:pick|random|roll)\s?:?:?([^}]+)}}/gi;
-			}
+				let stablereg = "";
+				if(!isgametext)
+				{
+					inputtxt = inputtxt.replace(/\{\{roll\s?:?:?([^\}\n]{1,250})\}\}/gi, function (m,matchValue) {
+						return dicenotation(matchValue, 0);
+					});
+					inputtxt = inputtxt.replace(/\{\{random\s?:?:?([^\}\n]{1,250})\}\}/gi, function (m,listString) {
+						return pickfromlist(listString,0);
+					});
+					stablereg = /\{\{(pick)\s?:?:?([^\}\n]{1,250})\}\}/gi;
+				}
+				else
+				{
+					stablereg = /\{\{(pick|random|roll)\s?:?:?([^\}\n]{1,250})\}\}/gi;
+				}
 
-			let countmap = new Map();
-			let accum = '';
-			let lastIndex = 0;
-			let match;
-			while ((match = stablereg.exec(inputtxt)) !== null) {
-				accum += inputtxt.substring(lastIndex,match.index);
-				const matchtxt = match[1];
-				const count = countmap.get(matchtxt) || 0;
-				countmap.set(matchtxt, count + 1);
-				let hashstr = matchtxt + localsettings.inject_randomness_seed;
-				if (isgametext || (match[0].toLowerCase().substring(2,6) !== "pick")) { hashstr += count; }
-				accum += ((match[0].toLowerCase().substring(2,6) == "roll") ? dicenotation : pickfromlist)(matchtxt,parseInt("0x"+cyrb_hash(hashstr)));
-				lastIndex = stablereg.lastIndex;
+				let countmap = new Map();
+				let parts = [];
+				let lastIndex = 0;
+				let match;
+
+				while ((match = stablereg.exec(inputtxt)) !== null) {
+					const tagType = match[1].toLowerCase();
+					const matchtxt = match[2];
+					parts.push(inputtxt.substring(lastIndex, match.index));
+					let count = countmap.get(matchtxt) || 0;
+					countmap.set(matchtxt, count + 1);
+					let hashstr = matchtxt + localsettings.inject_randomness_seed;
+					if (isgametext || tagType !== "pick") {
+						hashstr += count;
+					}
+					let seed = parseInt(cyrb_hash(hashstr), 16);
+					let replacement = (tagType === "roll" ? dicenotation : pickfromlist)(matchtxt, seed);
+					parts.push(replacement);
+					lastIndex = stablereg.lastIndex;
+				}
+				parts.push(inputtxt.substring(lastIndex));	// Add remaining text after the last match
+				inputtxt = parts.join('');
 			}
-			inputtxt = accum+inputtxt.substring(lastIndex);
 		}
 		return inputtxt;
 	}
 	//if alwaysreplace, then settings are not considered, otherwise checks settings
+	//if isgametext is true, then keeping the random values stable will be prioritized
 	function replace_placeholders(inputtxt, escape=false, alwaysreplace=false, isgametext=true)
 	{
 		inputtxt = replace_instruct_placeholders(inputtxt);
@@ -8038,7 +8059,7 @@ Current version indicated by LITEVER below.
 			gametext_arr = [];
 			if(!localsettings.placeholder_tags) //do a one-time replace instead
 			{
-				greeting = replace_placeholders(greeting, false, true, true);
+				greeting = replace_placeholders(greeting, false, true, false); //this is all onetime replacements, no need for stability
 				combinedmem = replace_placeholders(combinedmem, false, true, false);
 			}
 			if(greeting)
@@ -8098,7 +8119,7 @@ Current version indicated by LITEVER below.
 			let prompttxt = temp_scenario.prompt;
 			if(!localsettings.placeholder_tags) //do a one-time replace instead
 			{
-				prompttxt = replace_placeholders(prompttxt, false, true, true);
+				prompttxt = replace_placeholders(prompttxt, false, true, false);
 			}
 			gametext_arr.push(prompttxt);
 		}
@@ -13151,8 +13172,11 @@ Current version indicated by LITEVER below.
 			documentdb_chunksize = 800;
 			documentdb_data = "";
 		}
-		new_randomness_seed();
-		localsettings.inject_randomness_seed = document.getElementById("inject_randomness_seed").value;
+		if(localsettings.inject_randomness_seed>0)
+		{
+			new_randomness_seed();
+			localsettings.inject_randomness_seed = document.getElementById("inject_randomness_seed").value;
+		}
 		warn_unsaved = false;
 		last_used_saveslot = -1;
 		show_corpo_leftpanel(false);
@@ -13184,7 +13208,7 @@ Current version indicated by LITEVER below.
 
 	function new_randomness_seed()
 	{
-		document.getElementById("inject_randomness_seed").value = Math.floor(Math.random() * Math.pow(2,32));
+		document.getElementById("inject_randomness_seed").value = (Math.floor(Math.random() * 99999)); //keep within a simple range
 	}
 
 	function btn_editmode()
@@ -15037,7 +15061,7 @@ Current version indicated by LITEVER below.
 			//only do this processing if memory or anote is not blank
 			if (truncated_memory.length > 0 || current_anote.length > 0)
 			{
-				truncated_memory = replace_placeholders(truncated_memory,false,false,false);
+				truncated_memory = replace_placeholders(truncated_memory,false,false,true);
 				truncated_anote = replace_placeholders(truncated_anote,false,false,false);
 				if(!is_using_kcpp_with_added_memory())
 				{
@@ -21507,9 +21531,9 @@ Current version indicated by LITEVER below.
 		allText = replaceAll(allText,recentTextStr,"");
 
 		// Ensure placeholders are replaced to allow searching for user / character
-		allText = replace_search_placeholders(allText,isstorage=true)
-		searchStr = replace_search_placeholders(searchStr)
-		recentTextStr = replace_search_placeholders(recentTextStr)
+		allText = replace_search_placeholders(allText);
+		searchStr = replace_search_placeholders(searchStr);
+		recentTextStr = replace_search_placeholders(recentTextStr);
 
 		let i = 0, startLoc = 0;
 		while (startLoc < allText.length && i < Number.MAX_SAFE_INTEGER) {
@@ -22891,7 +22915,7 @@ Current version indicated by LITEVER below.
 						<table id="placeholder_replace_table" class="settinglabel" style="text-align: center; border-spacing: 3px 2px; border-collapse: separate;">
 						</table>
 						<div style="padding:3px" class="settinglabel justifyleft">
-							Randomness Seed: <span class="helpicon">?<span class="helptext">A seed to generate randomness for {{pick}}, {{roll}} and {{random}}. Set to -1 to disable these three placeholders.</span></span><input class="settinglabel miniinput" style="margin-left:4px;width:100px;" type="text" inputmode="decimal" placeholder="0" value="1115215124" id="inject_randomness_seed"><button title="Regen" type="button" class="btn btn-primary bg_green" style="padding:1px 3px;margin:0px 0px 0px auto;font-size:10px;" onclick="new_randomness_seed()">Regen</button></div>
+							Randomness Seed: <span class="helpicon">?<span class="helptext">A seed to generate randomness for {{pick}}, {{roll}} and {{random}}. Set to -1 to disable these three placeholders.</span></span><input class="settinglabel miniinput" style="margin-left:4px;width:70px;" type="text" inputmode="decimal" placeholder="0" value="" id="inject_randomness_seed"><button title="Regen" type="button" class="btn btn-primary bg_green" style="padding:1px 3px;margin:0px 0px 0px auto;font-size:10px;" onclick="new_randomness_seed()">Regen</button></div>
 					</div>
 					<div style="padding:3px;" class="justifyleft settinglabel">Classifier-Free Guidance <span class="helpicon">?<span
 						class="helptext">Functions as a negative prompt when Guidance Scale is above 1.</span></span>

--- a/index.html
+++ b/index.html
@@ -3284,6 +3284,7 @@ Current version indicated by LITEVER below.
 		guidance_prompt: "",
 		guidance_scale: 1.0,
 		separate_end_tags: false,
+		enable_randomizing_tags: false,
 		idle_responses: 0,
 		idle_duration: 60,
 		export_settings: true, //affects if settings are included with the story and sharelinks
@@ -4286,6 +4287,34 @@ Current version indicated by LITEVER below.
 		text = text.replace(/\{\{\[SYSTEM\]\}\}/g, "").replace(/\{\{\[SYSTEM_END\]\}\}/g, "");
 		return text;
 	}
+
+	function inject_randomness(text,macro="pick",roll=true)
+	{
+		//Implements SillyTavern's PickReplace and DiceRoll macros, for compatibility with existing cards
+		text = text.replace(new RegExp("{{"+macro+"\s?::?([^}]+)}}","gi"), function (m, listString) {
+			const list = listString.includes('::') ? listString.split('::') : listString.replace(/\\,/g, '##�COMMA�##').split(',').map(item => item.trim().replace(/##�COMMA�##/g, ','));
+			return (list.length===0 ? '' : list[Math.floor(Math.random()*list.length)]);
+		});
+
+		if(roll){
+			text = text.replace(/{{roll[ : ]([^}]+)}}/gi, function (m, matchValue) {
+				let formula = matchValue.trim();
+				if (/^\d+$/.test(formula)){ formula = "1d${formula}"; }
+				pieces = formula.match(/^([1-9]\d*)?d([1-9]\d*)([x*×]\d+)?([+-]\d+)?$/i);
+				if (!pieces) {
+					return "";
+				}
+				var total = 0;
+				for (let a = 0; a < ((pieces[1]-0)||1); ++a) {
+					total += (1+Math.floor(Math.random()*pieces[2]));
+				}
+				total = total*((pieces[3].substring(1)-0)||1)+((pieces[4]-0)||0);
+				return String(total);
+			});
+		}
+		return text;
+	}
+
 	function replace_search_placeholders(text) {
 
 		// Remove any instruct tags as needed to ensure a more accurate search
@@ -4316,6 +4345,9 @@ Current version indicated by LITEVER below.
 	}
 	function replace_noninstruct_placeholders(inputtxt,escape=false)
 	{
+		if (localsettings.enable_randomizing_tags) {
+			inputtxt = inject_randomness(inputtxt,macro="random",roll=false);
+		}
 		let firstopponent = localsettings.chatopponent;
 		if (firstopponent && firstopponent.includes("||$||")) {
 			let coarr = firstopponent.split("||$||");
@@ -11457,6 +11489,7 @@ Current version indicated by LITEVER below.
 		document.getElementById("inject_chatnames_instruct").checked = localsettings.inject_chatnames_instruct;
 		document.getElementById("inject_jailbreak_instruct").checked = localsettings.inject_jailbreak_instruct;
 		document.getElementById("separate_end_tags").checked = localsettings.separate_end_tags;
+		document.getElementById("enable_randomizing_tags").checked = localsettings.enable_randomizing_tags;
 		document.getElementById("idle_responses").value = localsettings.idle_responses;
 		document.getElementById("idle_duration").value = localsettings.idle_duration;
 		document.getElementById("fix_alpaca_leak").checked = localsettings.fix_alpaca_leak;
@@ -11920,6 +11953,7 @@ Current version indicated by LITEVER below.
 		localsettings.inject_chatnames_instruct = (document.getElementById("inject_chatnames_instruct").checked ? true : false);
 		localsettings.inject_jailbreak_instruct = (document.getElementById("inject_jailbreak_instruct").checked ? true : false);
 		localsettings.separate_end_tags = (document.getElementById("separate_end_tags").checked ? true : false);
+		localsettings.enable_randomizing_tags = (document.getElementById("enable_randomizing_tags").checked ? true : false);
 		localsettings.idle_responses = document.getElementById("idle_responses").value;
 		localsettings.idle_duration = document.getElementById("idle_duration").value;
 		localsettings.fix_alpaca_leak = (document.getElementById("fix_alpaca_leak").checked ? true : false);
@@ -12522,6 +12556,14 @@ Current version indicated by LITEVER below.
 		documentdb_searchrange = cleannum(documentdb_searchrange,0,1024);
 		documentdb_chunksize = parseInt(documentdb_chunksize);
 		documentdb_chunksize = cleannum(documentdb_chunksize,32,2048);
+
+		if(localsettings.enable_randomizing_tags)
+		{
+			current_memory = inject_randomness(current_memory,macro="pick",roll=true);
+			current_anote = inject_randomness(current_anote,macro="pick",roll=true);
+			gametext_arr = gametext_arr.map(txt => inject_randomness(txt,macro="pick",roll=true));
+		}
+
 	}
 
 	function set_personal_notes()
@@ -14180,6 +14222,12 @@ Current version indicated by LITEVER below.
 		let img_gen_trigger_prompt = "";
 		let doNotGenerate = false;
 		retry_in_progress = false;
+
+		//inject randomness
+		if(localsettings.enable_randomizing_tags)
+		{
+			newgen = inject_randomness(newgen,macro="(?:pick|random)",roll=true);
+		}
 
 		//match the request for creating images in instruct modes
 		if(newgen!="" && localsettings.img_gen_from_instruct && localsettings.opmode == 4 && localsettings.generate_images_mode!=0 && !newgen.includes("\n"))
@@ -21905,6 +21953,11 @@ Current version indicated by LITEVER below.
 							<div class="justifyleft settingsmall">Separate End Tags <span class="helpicon">?<span
 								class="helptext">Allows using separate Instruction and Response End Tags, instead of combing them with the start tag. Not recommended for beginners.</span></span></div>
 							<input type="checkbox" title="Separate End Tags" id="separate_end_tags" style="margin:0px 0px 0px auto;" onchange="toggle_separate_end_tags()">
+						<div class="settinglabel">
+							<div class="justifyleft settingsmall">Randomizing Tags <span class="helpicon">?<span
+								class="helptext">Enables randomizing tags, like {{pick:option1,option2,option3}} or {{roll:2d6}}.</span></span></div>
+							<input type="checkbox" title="Randomizing Tags" id="enable_randomizing_tags" style="margin:0px 0px 0px auto;">
+						</div>
 						</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -4356,7 +4356,7 @@ Current version indicated by LITEVER below.
 		inputtxt = replaceAll(inputtxt,instructsysplaceholder_end.trim(),get_instruct_systag_end(false));
 		return inputtxt;
 	}
-	function replace_noninstruct_placeholders(inputtxt,escape=false,isgametext=true)
+	function replace_noninstruct_placeholders(inputtxt,escape=false,isgametext=true,persistent_countmap=null)
 	{
 		let firstopponent = localsettings.chatopponent;
 		if (firstopponent && firstopponent.includes("||$||")) {
@@ -4434,7 +4434,7 @@ Current version indicated by LITEVER below.
 					stablereg = /\{\{(pick|random|roll)\s?:?:?([^\}\n]{1,500})\}\}/gi;
 				}
 
-				let countmap = new Map();
+				let countmap = (persistent_countmap?persistent_countmap:new Map());
 				let parts = [];
 				let lastIndex = 0;
 				let match;
@@ -4467,7 +4467,7 @@ Current version indicated by LITEVER below.
 		inputtxt = replace_instruct_placeholders(inputtxt);
 		if(alwaysreplace || localsettings.placeholder_tags)
 		{
-			inputtxt = replace_noninstruct_placeholders(inputtxt,escape,isgametext);
+			inputtxt = replace_noninstruct_placeholders(inputtxt,escape,isgametext,null);
 		}
 		return inputtxt;
 	}
@@ -19454,6 +19454,7 @@ Current version indicated by LITEVER below.
 
 		let incomplete_resp = (synchro_pending_stream!="" || pending_response_id!="");
 
+		let countmap = new Map();
 		for(var i=0;i<chatunits.length;++i)
 		{
 			let curr = chatunits[i];
@@ -19462,7 +19463,7 @@ Current version indicated by LITEVER below.
 			processed_msg = apply_display_only_regex(processed_msg);
 			if(processed_msg && processed_msg!="")
 			{
-				processed_msg = replace_noninstruct_placeholders(processed_msg,true);
+				processed_msg = replace_noninstruct_placeholders(processed_msg,true,true,countmap);
 				let codeblockcount = (processed_msg.match(/```/g) || []).length;
 				if(codeblockcount>0 && codeblockcount%2!=0 )
 				{

--- a/index.html
+++ b/index.html
@@ -3234,6 +3234,7 @@ Current version indicated by LITEVER below.
 		instruct_has_latex: true,
 		placeholder_tags: true,
 		render_special_tags: false,
+		inject_randomness_seed: 1115215124,
 		request_logprobs: false,
 		persist_session: true,
 		speech_synth: 0, //0 is disabled, 1000 is xtts
@@ -3284,7 +3285,6 @@ Current version indicated by LITEVER below.
 		guidance_prompt: "",
 		guidance_scale: 1.0,
 		separate_end_tags: false,
-		enable_randomizing_tags: false,
 		idle_responses: 0,
 		idle_duration: 60,
 		export_settings: true, //affects if settings are included with the story and sharelinks
@@ -3565,6 +3565,14 @@ Current version indicated by LITEVER below.
 		//truncate to first 3 bytes
 		return hsh.substring(0, 6);
 	};
+	function basic_LCG(seed) { //simple RNG for reproducible dicerolls
+		var m = 2**35 - 31;
+		var a = 185852;
+		var s = seed % m;
+		return function () {
+			return (s = s * a % m) / m
+		}
+	}
 	function import_props_into_object(existingObj, objToImport) { //import new fields from one object into another while preserving exsting
 		for (var k in objToImport) {
 			existingObj[k] = objToImport[k];
@@ -4303,7 +4311,7 @@ Current version indicated by LITEVER below.
 		text = text.replace(new RegExp("{{"+rollmacro+"\s?:?:?([^}]+)}}","gi"), function (m, matchValue){
 			let formula = matchValue.trim();
 			if (/^\d+$/.test(formula)){ formula = "1d${formula}"; }
-			pieces = formula.match(/^([1-9]\d*)?d([1-9]\d*)([x*\u00D7][\d]*\.?[\d]+)?([+-][\d]*\.?[\d]+)?$/i);
+			pieces = formula.match(/^([1-9]\d*)?d([1-9]\d*)([x*\u00D7][\d.]+)?([+-][\d.]+)?$/i);
 			if (!pieces) {
 				return "";
 			}
@@ -4319,13 +4327,13 @@ Current version indicated by LITEVER below.
 		return text;
 	}
 
-	function replace_search_placeholders(text) {
+	function replace_search_placeholders(text,isstorage=false) {
 
 		// Remove any instruct tags as needed to ensure a more accurate search
 		text = remove_all_instruct_tags(text);
 
 		// Replace {{user}} and other placeholders
-		text = replace_placeholders(text);
+		text = replace_placeholders(text,isgametext=!isstorage);
 
 		return text;
 	}
@@ -4347,7 +4355,7 @@ Current version indicated by LITEVER below.
 		inputtxt = replaceAll(inputtxt,instructsysplaceholder_end.trim(),get_instruct_systag_end(false));
 		return inputtxt;
 	}
-	function replace_noninstruct_placeholders(inputtxt,escape=false)
+	function replace_noninstruct_placeholders(inputtxt,escape=false,isgametext=true)
 	{
 		let firstopponent = localsettings.chatopponent;
 		if (firstopponent && firstopponent.includes("||$||")) {
@@ -4373,15 +4381,71 @@ Current version indicated by LITEVER below.
 				inputtxt = replaceAll(inputtxt,localsettings.placeholder_tags_data[i].p,localsettings.placeholder_tags_data[i].r);
 			}
 		}
+
+		if(localsettings.inject_randomness_seed!=-1)
+		{
+			// define helper functions
+			let dicenotation = function(formula,seed=0){
+				RNG = seed ? basic_LCG(seed) : Math.random;
+				formula = formula.trim();
+				if (/^\d+$/.test(formula)){ formula = "1d${formula}"; }
+				const pieces = formula.match(/^(\d+)?d(\d+)([x*\u00D7]\d*\.?\d+)?([+-]\d*\.?\d+)?$/i);
+				if (!pieces) {
+					return "";
+				}
+				let total = (pieces[1]-0)||1;
+				for (let i=0; i < ((pieces[1]-0)||1); ++i) {
+					total += Math.floor(RNG()*pieces[2]);
+				}
+				total *= pieces[3] ? parseFloat(pieces[3].substring(1)) : 1;
+				total += pieces[4] ? parseFloat(pieces[4]) : 0;
+				return String(total);
+			}
+			let pickfromlist = function(listString,seed=0){
+				const list = listString.includes('::') ? listString.split('::') : listString.replace(/\\,/g, '{{COMMA}}').split(',').map(item => item.trim().replace(/{{COMMA}}/g, ','));
+				return (list.length===0 ? '' : list[Math.floor((seed ? seed/(2**24) : Math.random())*list.length)]);
+			}
+
+			if(!isgametext)
+			{
+	 			inputtxt = inputtxt.replace(/{{roll\s?:?:?([^}]+)}}/gi, function (m,matchValue) {
+					return dicenotation(matchValue, 0);
+				});
+				inputtxt = inputtxt.replace(/{{random\s?:?:?([^}]+)}}/gi, function (m,listString) {
+					return pickfromlist(listString,0);
+				});
+				stablereg = /{{pick\s?::?([^}]+)}}/gi;
+			}
+			else
+			{
+				stablereg = /{{(?:pick|random|roll)\s?::?([^}]+)}}/gi;
+			}
+
+			let countmap = new Map();
+			let accum = '';
+			let lastIndex = 0;
+			let match;
+			while ((match = stablereg.exec(inputtxt)) !== null) {
+				accum += inputtxt.substring(lastIndex,match.index);
+				const matchtxt = match[0];
+				const count = countmap.get(matchtxt) || 0;
+				countmap.set(matchtxt, count + 1);
+				let hashstr = matchtxt + localsettings.inject_randomness_seed;
+				if (!(/[kK]/.test(inputtxt.substring(match.index-4,match.index)))) { hashstr += count; }
+				accum += (/[lL]/.test(inputtxt.substring(match.index-4,match.index)) ? dicenotation : pickfromlist)(matchtxt,parseInt("0x"+cyrb_hash(hashstr)));
+				lastIndex = stablereg.lastIndex;
+			}
+			inputtxt = accum+inputtxt.substring(lastIndex);
+		}
 		return inputtxt;
 	}
 	//if alwaysreplace, then settings are not considered, otherwise checks settings
-	function replace_placeholders(inputtxt, escape=false, alwaysreplace=false)
+	function replace_placeholders(inputtxt, escape=false, alwaysreplace=false, isgametext=true)
 	{
 		inputtxt = replace_instruct_placeholders(inputtxt);
 		if(alwaysreplace || localsettings.placeholder_tags)
 		{
-			inputtxt = replace_noninstruct_placeholders(inputtxt,escape);
+			inputtxt = replace_noninstruct_placeholders(inputtxt,escape,isgametext);
 		}
 		return inputtxt;
 	}
@@ -7828,8 +7892,8 @@ Current version indicated by LITEVER below.
 			gametext_arr = [];
 			if(!localsettings.placeholder_tags) //do a one-time replace instead
 			{
-				greeting = replace_placeholders(greeting, false, true);
-				combinedmem = replace_placeholders(combinedmem, false, true);
+				greeting = replace_placeholders(greeting, false, true, true);
+				combinedmem = replace_placeholders(combinedmem, false, true, false);
 			}
 			if(greeting)
 			{
@@ -7888,7 +7952,7 @@ Current version indicated by LITEVER below.
 			let prompttxt = temp_scenario.prompt;
 			if(!localsettings.placeholder_tags) //do a one-time replace instead
 			{
-				prompttxt = replace_placeholders(prompttxt, false, true);
+				prompttxt = replace_placeholders(prompttxt, false, true, true);
 			}
 			gametext_arr.push(prompttxt);
 		}
@@ -7896,14 +7960,14 @@ Current version indicated by LITEVER below.
 			current_anote = temp_scenario.authorsnote;
 			if(!localsettings.placeholder_tags)
 			{
-				current_anote = replace_placeholders(current_anote, false, true);
+				current_anote = replace_placeholders(current_anote, false, true, false);
 			}
 		}
 		if (temp_scenario.memory != "") {
 			current_memory = temp_scenario.memory;
 			if(!localsettings.placeholder_tags)
 			{
-				current_memory = replace_placeholders(current_memory, false, true);
+				current_memory = replace_placeholders(current_memory, false, true, false);
 			}
 		}
 		if (temp_scenario.image && temp_scenario.image != "") {
@@ -11490,7 +11554,6 @@ Current version indicated by LITEVER below.
 		document.getElementById("inject_chatnames_instruct").checked = localsettings.inject_chatnames_instruct;
 		document.getElementById("inject_jailbreak_instruct").checked = localsettings.inject_jailbreak_instruct;
 		document.getElementById("separate_end_tags").checked = localsettings.separate_end_tags;
-		document.getElementById("enable_randomizing_tags").checked = localsettings.enable_randomizing_tags;
 		document.getElementById("idle_responses").value = localsettings.idle_responses;
 		document.getElementById("idle_duration").value = localsettings.idle_duration;
 		document.getElementById("fix_alpaca_leak").checked = localsettings.fix_alpaca_leak;
@@ -11499,6 +11562,7 @@ Current version indicated by LITEVER below.
 		document.getElementById("instruct_has_markdown").checked = localsettings.instruct_has_markdown;
 		document.getElementById("instruct_has_latex").checked = localsettings.instruct_has_latex;
 		document.getElementById("placeholder_tags").checked = localsettings.placeholder_tags;
+		document.getElementById("inject_randomness_seed").value = localsettings.inject_randomness_seed;
 		document.getElementById("run_in_background").checked = run_in_background;
 		document.getElementById("auto_ctxlen").checked = localsettings.auto_ctxlen;
 		document.getElementById("auto_genamt").checked = localsettings.auto_genamt;
@@ -11954,7 +12018,6 @@ Current version indicated by LITEVER below.
 		localsettings.inject_chatnames_instruct = (document.getElementById("inject_chatnames_instruct").checked ? true : false);
 		localsettings.inject_jailbreak_instruct = (document.getElementById("inject_jailbreak_instruct").checked ? true : false);
 		localsettings.separate_end_tags = (document.getElementById("separate_end_tags").checked ? true : false);
-		localsettings.enable_randomizing_tags = (document.getElementById("enable_randomizing_tags").checked ? true : false);
 		localsettings.idle_responses = document.getElementById("idle_responses").value;
 		localsettings.idle_duration = document.getElementById("idle_duration").value;
 		localsettings.fix_alpaca_leak = (document.getElementById("fix_alpaca_leak").checked ? true : false);
@@ -11963,6 +12026,7 @@ Current version indicated by LITEVER below.
 		localsettings.instruct_has_markdown = (document.getElementById("instruct_has_markdown").checked ? true : false);
 		localsettings.instruct_has_latex = (document.getElementById("instruct_has_latex").checked ? true : false);
 		localsettings.placeholder_tags = (document.getElementById("placeholder_tags").checked ? true : false);
+		localsettings.inject_randomness_seed = document.getElementById("inject_randomness_seed").value;
 		run_in_background = (document.getElementById("run_in_background").checked ? true : false);
 		background_audio_loop(run_in_background);
 		localsettings.generate_images_model = document.getElementById("generate_images_model").value;
@@ -12557,13 +12621,6 @@ Current version indicated by LITEVER below.
 		documentdb_searchrange = cleannum(documentdb_searchrange,0,1024);
 		documentdb_chunksize = parseInt(documentdb_chunksize);
 		documentdb_chunksize = cleannum(documentdb_chunksize,32,2048);
-
-		if(localsettings.enable_randomizing_tags)
-		{
-			current_memory = inject_randomness(current_memory,onlystable=true);
-			current_anote = inject_randomness(current_anote,onlystable=true);
-		}
-
 	}
 
 	function set_personal_notes()
@@ -12931,6 +12988,7 @@ Current version indicated by LITEVER below.
 			documentdb_searchrange = 300;
 			documentdb_chunksize = 800;
 			documentdb_data = "";
+			new_randomness_seed(); 
 		}
 		warn_unsaved = false;
 		last_used_saveslot = -1;
@@ -12959,6 +13017,12 @@ Current version indicated by LITEVER below.
 			styleElement.innerHTML = "";
 		},null);
 
+	}
+
+	function new_randomness_seed()
+	{
+		localsettings.inject_randomness_seed = Math.floor(Math.random() * Math.pow(2,32));
+		document.getElementById("inject_randomness_seed").value = localsettings.inject_randomness_seed;
 	}
 
 	function btn_editmode()
@@ -13282,6 +13346,10 @@ Current version indicated by LITEVER below.
 
 	function do_manual_gen_image(sentence, base64img="") //b64 for img2img
 	{
+		if(localsettings.placeholder_tags)
+		{
+			sentence = replace_placeholders(sentence)
+		}
 		generate_new_image(sentence, base64img);
 		document.getElementById("btn_genimg").disabled = true;
 		document.getElementById("btn_genimg2").disabled = true;
@@ -14223,14 +14291,6 @@ Current version indicated by LITEVER below.
 		let doNotGenerate = false;
 		retry_in_progress = false;
 
-		//inject randomness
-		if(localsettings.enable_randomizing_tags)
-		{
-			newgen = inject_randomness(newgen,onlystable=false);
-			//since user could have edited the gametext to manually inject macros, we need a one-time replacement
-			gametext_arr = gametext_arr.map(txt => inject_randomness(txt,false));
-		}
-
 		//match the request for creating images in instruct modes
 		if(newgen!="" && localsettings.img_gen_from_instruct && localsettings.opmode == 4 && localsettings.generate_images_mode!=0 && !newgen.includes("\n"))
 		{
@@ -14394,12 +14454,6 @@ Current version indicated by LITEVER below.
 				}
 			}
 			
-			//replace all randomizing tags
-			if(localsettings.embed_randomizing_tags)
-			{
-				truncated_context = inject_randomness(truncated_context,onlystable=false);
-			}
-
 			let max_allowed_characters = getMaxAllowedCharacters(truncated_context, maxctxlen, maxgenamt);
 
 			//for adventure mode, inject hidden context, even more if there's nothing in memory
@@ -14595,13 +14649,9 @@ Current version indicated by LITEVER below.
 				{
 					appendedsysprompt += get_instruct_systag_end(false);
 				}
-				if(localsettings.enable_randomizing_tags)
-				{
-					appendedsysprompt = inject_randomness(appendedsysprompt,onlystable=false);
-				}
 				appendedsysprompt += "\n";
 			}
-			let truncated_memory = substring_to_boundary(localsettings.enable_randomizing_tags ? inject_randomness(current_memory,onlystable=false) : current_memory, max_mem_len);
+			let truncated_memory = substring_to_boundary(current_memory, max_mem_len);
 			if (truncated_memory != null && truncated_memory != "") {
 				if(newlineaftermemory)
 				{
@@ -14790,12 +14840,12 @@ Current version indicated by LITEVER below.
 			//limit wi size
 			if(wistr!="")
 			{
-				wistr = substring_to_boundary(localsettings.enable_randomizing_tags ? inject_randomness(wistr,onlystable=false) : wistr, max_wi_len);
+				wistr = substring_to_boundary(wistr, max_wi_len);
 			}
 
 			//we clip the authors note if its too long
 			let truncated_anote = current_anotetemplate.replace("<|>", current_anote);
-			truncated_anote = substring_to_boundary(localsettings.enable_randomizing_tags ? inject_randomness(truncated_anote,onlystable=false) : truncated_anote, max_anote_len);
+			truncated_anote = substring_to_boundary(truncated_anote, max_anote_len);
 
 			if (current_anote.length == 0) {
 				//if there's no authors note at all, don't include the template
@@ -14854,8 +14904,8 @@ Current version indicated by LITEVER below.
 				}
 			}
 
-			truncated_memory = replace_placeholders(truncated_memory);
-			truncated_context = replace_placeholders(truncated_context);
+			truncated_memory = replace_placeholders(truncated_memory,isgametext=false);
+			truncated_context = replace_placeholders(truncated_context,isgametext=true);
 
 			if(is_using_kcpp_with_added_memory())
 			{
@@ -18598,7 +18648,7 @@ Current version indicated by LITEVER below.
 			else
 			{
 				let textToRender = concat_gametext(false, "", "", "", true);
-				document.getElementById("corpo_body").innerHTML = render_corpo_ui(textToRender);
+				document.getElementById("corpo_body").innerHTML = render_corpo_ui(textToRender,true);
 				corpoedit_resize_input();
 			}
 
@@ -21305,7 +21355,7 @@ Current version indicated by LITEVER below.
 		allText = replaceAll(allText,recentTextStr,"");
 
 		// Ensure placeholders are replaced to allow searching for user / character
-		allText = replace_search_placeholders(allText)
+		allText = replace_search_placeholders(allText,isstorage=true)
 		searchStr = replace_search_placeholders(searchStr)
 		recentTextStr = replace_search_placeholders(recentTextStr)
 
@@ -21965,11 +22015,6 @@ Current version indicated by LITEVER below.
 							<div class="justifyleft settingsmall">Separate End Tags <span class="helpicon">?<span
 								class="helptext">Allows using separate Instruction and Response End Tags, instead of combing them with the start tag. Not recommended for beginners.</span></span></div>
 							<input type="checkbox" title="Separate End Tags" id="separate_end_tags" style="margin:0px 0px 0px auto;" onchange="toggle_separate_end_tags()">
-						</div>
-						<div class="settinglabel">
-							<div class="justifyleft settingsmall">Randomizing Tags <span class="helpicon">?<span
-								class="helptext">Enables randomizing tags, like {{pick:option1,option2,option3}} or {{roll:2d6}}.</span></span></div>
-							<input type="checkbox" title="Randomizing Tags" id="enable_randomizing_tags" style="margin:0px 0px 0px auto;">
 						</div>
 					</div>
 				</div>
@@ -22672,6 +22717,8 @@ Current version indicated by LITEVER below.
 						</div>
 						<table id="placeholder_replace_table" class="settinglabel" style="text-align: center; border-spacing: 3px 2px; border-collapse: separate;">
 						</table>
+						<div style="padding:3px" class="settinglabel justifyleft">
+							Randomness Seed: <span class="helpicon">?<span class="helptext">A seed to generate randomness for {{pick}}, {{roll}} and {{random}}. Set to -1 to disable these placeholders.</span></span><input class="settinglabel miniinput" style="margin-left:4px;width:100px;" type="text" inputmode="decimal" placeholder="0" value="1115215124" id="inject_randomness_seed"><button title="Regen" type="button" class="btn btn-primary bg_green" style="padding:1px 3px;margin:0px 0px 0px auto;font-size:10px;" onclick="new_randomness_seed()">Regen</button></div>
 					</div>
 					<div style="padding:3px;" class="justifyleft settinglabel">Classifier-Free Guidance <span class="helpicon">?<span
 						class="helptext">Functions as a negative prompt when Guidance Scale is above 1.</span></span>

--- a/index.html
+++ b/index.html
@@ -4382,11 +4382,11 @@ Current version indicated by LITEVER below.
 				inputtxt = inputtxt.replace(/{{random\s?:?:?([^}]+)}}/gi, function (m,listString) {
 					return pickfromlist(listString,0);
 				});
-				stablereg = /{{(?:pick)\s?::?([^}]+)}}/gi;
+				stablereg = /{{(?:pick)\s?:?:?([^}]+)}}/gi;
 			}
 			else
 			{
-				stablereg = /{{(?:pick|random|roll)\s?::?([^}]+)}}/gi;
+				stablereg = /{{(?:pick|random|roll)\s?:?:?([^}]+)}}/gi;
 			}
 
 			let countmap = new Map();
@@ -18616,7 +18616,7 @@ Current version indicated by LITEVER below.
 			else
 			{
 				let textToRender = concat_gametext(false, "", "", "", true);
-				document.getElementById("corpo_body").innerHTML = render_corpo_ui(textToRender,true);
+				document.getElementById("corpo_body").innerHTML = render_corpo_ui(textToRender);
 				corpoedit_resize_input();
 			}
 
@@ -22686,7 +22686,7 @@ Current version indicated by LITEVER below.
 						<table id="placeholder_replace_table" class="settinglabel" style="text-align: center; border-spacing: 3px 2px; border-collapse: separate;">
 						</table>
 						<div style="padding:3px" class="settinglabel justifyleft">
-							Randomness Seed: <span class="helpicon">?<span class="helptext">A seed to generate randomness for {{pick}}, {{roll}} and {{random}}. Set to -1 to disable these placeholders.</span></span><input class="settinglabel miniinput" style="margin-left:4px;width:100px;" type="text" inputmode="decimal" placeholder="0" value="1115215124" id="inject_randomness_seed"><button title="Regen" type="button" class="btn btn-primary bg_green" style="padding:1px 3px;margin:0px 0px 0px auto;font-size:10px;" onclick="new_randomness_seed()">Regen</button></div>
+							Randomness Seed: <span class="helpicon">?<span class="helptext">A seed to generate randomness for {{pick}}, {{roll}} and {{random}}. Set to -1 to disable these three placeholders.</span></span><input class="settinglabel miniinput" style="margin-left:4px;width:100px;" type="text" inputmode="decimal" placeholder="0" value="1115215124" id="inject_randomness_seed"><button title="Regen" type="button" class="btn btn-primary bg_green" style="padding:1px 3px;margin:0px 0px 0px auto;font-size:10px;" onclick="new_randomness_seed()">Regen</button></div>
 					</div>
 					<div style="padding:3px;" class="justifyleft settinglabel">Classifier-Free Guidance <span class="helpicon">?<span
 						class="helptext">Functions as a negative prompt when Guidance Scale is above 1.</span></span>

--- a/index.html
+++ b/index.html
@@ -4347,7 +4347,6 @@ Current version indicated by LITEVER below.
 	{
 		if (localsettings.enable_randomizing_tags) {
 			inputtxt = inject_randomness(inputtxt,macro="random",roll=false);
-			gametext_arr = gametext_arr.map(txt => inject_randomness(txt,macro="pick",roll=true));
 		}
 		let firstopponent = localsettings.chatopponent;
 		if (firstopponent && firstopponent.includes("||$||")) {
@@ -14227,6 +14226,7 @@ Current version indicated by LITEVER below.
 		if(localsettings.enable_randomizing_tags)
 		{
 			newgen = inject_randomness(newgen,macro="(?:pick|random)",roll=true);
+			gametext_arr = gametext_arr.map(txt => inject_randomness(txt,macro="pick",roll=true));
 		}
 
 		//match the request for creating images in instruct modes

--- a/index.html
+++ b/index.html
@@ -4414,7 +4414,7 @@ Current version indicated by LITEVER below.
 				inputtxt = inputtxt.replace(/{{random\s?:?:?([^}]+)}}/gi, function (m,listString) {
 					return pickfromlist(listString,0);
 				});
-				stablereg = /{{pick\s?::?([^}]+)}}/gi;
+				stablereg = /{{(?:pick)\s?::?([^}]+)}}/gi;
 			}
 			else
 			{
@@ -4427,12 +4427,12 @@ Current version indicated by LITEVER below.
 			let match;
 			while ((match = stablereg.exec(inputtxt)) !== null) {
 				accum += inputtxt.substring(lastIndex,match.index);
-				const matchtxt = match[0];
+				const matchtxt = match[1];
 				const count = countmap.get(matchtxt) || 0;
 				countmap.set(matchtxt, count + 1);
 				let hashstr = matchtxt + localsettings.inject_randomness_seed;
-				if (!(/[kK]/.test(inputtxt.substring(match.index-4,match.index)))) { hashstr += count; }
-				accum += (/[lL]/.test(inputtxt.substring(match.index-4,match.index)) ? dicenotation : pickfromlist)(matchtxt,parseInt("0x"+cyrb_hash(hashstr)));
+				if (isgametext || (match[0].substring(2,6) !== "pick")) { hashstr += count; }
+				accum += ((match[0].substring(2,6) == "roll") ? dicenotation : pickfromlist)(matchtxt,parseInt("0x"+cyrb_hash(hashstr)));
 				lastIndex = stablereg.lastIndex;
 			}
 			inputtxt = accum+inputtxt.substring(lastIndex);

--- a/index.html
+++ b/index.html
@@ -4292,7 +4292,7 @@ Current version indicated by LITEVER below.
 	{
 		//Implements SillyTavern's PickReplace and DiceRoll macros, for compatibility with existing cards
 		text = text.replace(new RegExp("{{"+macro+"\s?::?([^}]+)}}","gi"), function (m, listString) {
-			const list = listString.includes('::') ? listString.split('::') : listString.replace(/\\,/g, '##�COMMA�##').split(',').map(item => item.trim().replace(/##�COMMA�##/g, ','));
+			const list = listString.includes('::') ? listString.split('::') : listString.replace(/\\,/g, '{{COMMA}}').split(',').map(item => item.trim().replace(/{{COMMA}}/g, ','));
 			return (list.length===0 ? '' : list[Math.floor(Math.random()*list.length)]);
 		});
 
@@ -4300,7 +4300,7 @@ Current version indicated by LITEVER below.
 			text = text.replace(/{{roll[ : ]([^}]+)}}/gi, function (m, matchValue) {
 				let formula = matchValue.trim();
 				if (/^\d+$/.test(formula)){ formula = "1d${formula}"; }
-				pieces = formula.match(/^([1-9]\d*)?d([1-9]\d*)([x*×]\d+)?([+-]\d+)?$/i);
+				pieces = formula.match(/^([1-9]\d*)?d([1-9]\d*)([x*\u00D7]\d+)?([+-]\d+)?$/i);
 				if (!pieces) {
 					return "";
 				}
@@ -4347,6 +4347,7 @@ Current version indicated by LITEVER below.
 	{
 		if (localsettings.enable_randomizing_tags) {
 			inputtxt = inject_randomness(inputtxt,macro="random",roll=false);
+			gametext_arr = gametext_arr.map(txt => inject_randomness(txt,macro="pick",roll=true));
 		}
 		let firstopponent = localsettings.chatopponent;
 		if (firstopponent && firstopponent.includes("||$||")) {
@@ -12561,7 +12562,6 @@ Current version indicated by LITEVER below.
 		{
 			current_memory = inject_randomness(current_memory,macro="pick",roll=true);
 			current_anote = inject_randomness(current_anote,macro="pick",roll=true);
-			gametext_arr = gametext_arr.map(txt => inject_randomness(txt,macro="pick",roll=true));
 		}
 
 	}

--- a/index.html
+++ b/index.html
@@ -4308,7 +4308,7 @@ Current version indicated by LITEVER below.
 				for (let a = 0; a < ((pieces[1]-0)||1); ++a) {
 					total += (1+Math.floor(Math.random()*pieces[2]));
 				}
-				total = total*((pieces[3].substring(1)-0)||1)+((pieces[4]-0)||0);
+				total = total*(((pieces[3]??'').substring(1)-0)||1)+((pieces[4]-0)||0);
 				return String(total);
 			});
 		}

--- a/index.html
+++ b/index.html
@@ -21953,11 +21953,11 @@ Current version indicated by LITEVER below.
 							<div class="justifyleft settingsmall">Separate End Tags <span class="helpicon">?<span
 								class="helptext">Allows using separate Instruction and Response End Tags, instead of combing them with the start tag. Not recommended for beginners.</span></span></div>
 							<input type="checkbox" title="Separate End Tags" id="separate_end_tags" style="margin:0px 0px 0px auto;" onchange="toggle_separate_end_tags()">
+						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Randomizing Tags <span class="helpicon">?<span
 								class="helptext">Enables randomizing tags, like {{pick:option1,option2,option3}} or {{roll:2d6}}.</span></span></div>
 							<input type="checkbox" title="Randomizing Tags" id="enable_randomizing_tags" style="margin:0px 0px 0px auto;">
-						</div>
 						</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -4288,30 +4288,34 @@ Current version indicated by LITEVER below.
 		return text;
 	}
 
-	function inject_randomness(text,macro="pick",roll=true)
+	function inject_randomness(text,onlystable=true)
 	{
 		//Implements SillyTavern's PickReplace and DiceRoll macros, for compatibility with existing cards
-		text = text.replace(new RegExp("{{"+macro+"\s?::?([^}]+)}}","gi"), function (m, listString) {
+
+		replacemacro = onlystable ? "pick" : "(?:pick|random)"
+		rollmacro = onlystable ? "toss" : "(?:roll|toss)"
+
+		text = text.replace(new RegExp("{{"+replacemacro+"\s?::?([^}]+)}}","gi"), function (m, listString) {
 			const list = listString.includes('::') ? listString.split('::') : listString.replace(/\\,/g, '{{COMMA}}').split(',').map(item => item.trim().replace(/{{COMMA}}/g, ','));
 			return (list.length===0 ? '' : list[Math.floor(Math.random()*list.length)]);
 		});
 
-		if(roll){
-			text = text.replace(/{{roll[ : ]([^}]+)}}/gi, function (m, matchValue) {
-				let formula = matchValue.trim();
-				if (/^\d+$/.test(formula)){ formula = "1d${formula}"; }
-				pieces = formula.match(/^([1-9]\d*)?d([1-9]\d*)([x*\u00D7]\d+)?([+-]\d+)?$/i);
-				if (!pieces) {
-					return "";
-				}
-				var total = 0;
-				for (let a = 0; a < ((pieces[1]-0)||1); ++a) {
-					total += (1+Math.floor(Math.random()*pieces[2]));
-				}
-				total = total*(((pieces[3]??'').substring(1)-0)||1)+((pieces[4]-0)||0);
-				return String(total);
-			});
-		}
+		text = text.replace(new RegExp("{{"+rollmacro+"\s?:?:?([^}]+)}}","gi"), function (m, matchValue){
+			let formula = matchValue.trim();
+			if (/^\d+$/.test(formula)){ formula = "1d${formula}"; }
+			pieces = formula.match(/^([1-9]\d*)?d([1-9]\d*)([x*\u00D7][\d]*\.?[\d]+)?([+-][\d]*\.?[\d]+)?$/i);
+			if (!pieces) {
+				return "";
+			}
+			var total = 0;
+			for (let a = 0; a < ((pieces[1]-0)||1); ++a) {
+				total += 1+Math.floor(Math.random()*pieces[2]);
+			}
+			total *= pieces[3] ? parseFloat(pieces[3].substring(1)) : 1
+			total += pieces[4] ? parseFloat(pieces[4]) : 0;
+			return String(total);
+		});
+
 		return text;
 	}
 
@@ -4345,9 +4349,6 @@ Current version indicated by LITEVER below.
 	}
 	function replace_noninstruct_placeholders(inputtxt,escape=false)
 	{
-		if (localsettings.enable_randomizing_tags) {
-			inputtxt = inject_randomness(inputtxt,macro="random",roll=false);
-		}
 		let firstopponent = localsettings.chatopponent;
 		if (firstopponent && firstopponent.includes("||$||")) {
 			let coarr = firstopponent.split("||$||");
@@ -12559,8 +12560,8 @@ Current version indicated by LITEVER below.
 
 		if(localsettings.enable_randomizing_tags)
 		{
-			current_memory = inject_randomness(current_memory,macro="pick",roll=true);
-			current_anote = inject_randomness(current_anote,macro="pick",roll=true);
+			current_memory = inject_randomness(current_memory,onlystable=true);
+			current_anote = inject_randomness(current_anote,onlystable=true);
 		}
 
 	}
@@ -14225,8 +14226,9 @@ Current version indicated by LITEVER below.
 		//inject randomness
 		if(localsettings.enable_randomizing_tags)
 		{
-			newgen = inject_randomness(newgen,macro="(?:pick|random)",roll=true);
-			gametext_arr = gametext_arr.map(txt => inject_randomness(txt,macro="pick",roll=true));
+			newgen = inject_randomness(newgen,onlystable=false);
+			//since user could have edited the gametext to manually inject macros, we need a one-time replacement
+			gametext_arr = gametext_arr.map(txt => inject_randomness(txt,false));
 		}
 
 		//match the request for creating images in instruct modes
@@ -14390,6 +14392,12 @@ Current version indicated by LITEVER below.
 						truncated_context = beforePart + afterPart; // Combine and done
 					}
 				}
+			}
+			
+			//replace all randomizing tags
+			if(localsettings.embed_randomizing_tags)
+			{
+				truncated_context = inject_randomness(truncated_context,onlystable=false);
 			}
 
 			let max_allowed_characters = getMaxAllowedCharacters(truncated_context, maxctxlen, maxgenamt);
@@ -14587,9 +14595,13 @@ Current version indicated by LITEVER below.
 				{
 					appendedsysprompt += get_instruct_systag_end(false);
 				}
+				if(localsettings.enable_randomizing_tags)
+				{
+					appendedsysprompt = inject_randomness(appendedsysprompt,onlystable=false);
+				}
 				appendedsysprompt += "\n";
 			}
-			let truncated_memory = substring_to_boundary(current_memory, max_mem_len);
+			let truncated_memory = substring_to_boundary(localsettings.enable_randomizing_tags ? inject_randomness(current_memory,onlystable=false) : current_memory, max_mem_len);
 			if (truncated_memory != null && truncated_memory != "") {
 				if(newlineaftermemory)
 				{
@@ -14778,12 +14790,12 @@ Current version indicated by LITEVER below.
 			//limit wi size
 			if(wistr!="")
 			{
-				wistr = substring_to_boundary(wistr, max_wi_len);
+				wistr = substring_to_boundary(localsettings.enable_randomizing_tags ? inject_randomness(wistr,onlystable=false) : wistr, max_wi_len);
 			}
 
 			//we clip the authors note if its too long
 			let truncated_anote = current_anotetemplate.replace("<|>", current_anote);
-			truncated_anote = substring_to_boundary(truncated_anote, max_anote_len);
+			truncated_anote = substring_to_boundary(localsettings.enable_randomizing_tags ? inject_randomness(truncated_anote,onlystable=false) : truncated_anote, max_anote_len);
 
 			if (current_anote.length == 0) {
 				//if there's no authors note at all, don't include the template

--- a/index.html
+++ b/index.html
@@ -4421,17 +4421,17 @@ Current version indicated by LITEVER below.
 				let stablereg = "";
 				if(!isgametext)
 				{
-					inputtxt = inputtxt.replace(/\{\{roll\s?:?:?([^\}\n]{1,250})\}\}/gi, function (m,matchValue) {
+					inputtxt = inputtxt.replace(/\{\{roll\s?:?:?([^\}\n]{1,500})\}\}/gi, function (m,matchValue) {
 						return dicenotation(matchValue, 0);
 					});
-					inputtxt = inputtxt.replace(/\{\{random\s?:?:?([^\}\n]{1,250})\}\}/gi, function (m,listString) {
+					inputtxt = inputtxt.replace(/\{\{random\s?:?:?([^\}\n]{1,500})\}\}/gi, function (m,listString) {
 						return pickfromlist(listString,0);
 					});
-					stablereg = /\{\{(pick)\s?:?:?([^\}\n]{1,250})\}\}/gi;
+					stablereg = /\{\{(pick)\s?:?:?([^\}\n]{1,500})\}\}/gi;
 				}
 				else
 				{
-					stablereg = /\{\{(pick|random|roll)\s?:?:?([^\}\n]{1,250})\}\}/gi;
+					stablereg = /\{\{(pick|random|roll)\s?:?:?([^\}\n]{1,500})\}\}/gi;
 				}
 
 				let countmap = new Map();

--- a/index.html
+++ b/index.html
@@ -4301,7 +4301,7 @@ Current version indicated by LITEVER below.
 		text = remove_all_instruct_tags(text);
 
 		// Replace {{user}} and other placeholders
-		text = replace_placeholders(text,isgametext=!isstorage);
+		text = replace_placeholders(text,false,false,!isstorage);
 
 		return text;
 	}
@@ -4399,8 +4399,8 @@ Current version indicated by LITEVER below.
 				const count = countmap.get(matchtxt) || 0;
 				countmap.set(matchtxt, count + 1);
 				let hashstr = matchtxt + localsettings.inject_randomness_seed;
-				if (isgametext || (match[0].substring(2,6) !== "pick")) { hashstr += count; }
-				accum += ((match[0].substring(2,6) == "roll") ? dicenotation : pickfromlist)(matchtxt,parseInt("0x"+cyrb_hash(hashstr)));
+				if (isgametext || (match[0].toLowerCase().substring(2,6) !== "pick")) { hashstr += count; }
+				accum += ((match[0].toLowerCase().substring(2,6) == "roll") ? dicenotation : pickfromlist)(matchtxt,parseInt("0x"+cyrb_hash(hashstr)));
 				lastIndex = stablereg.lastIndex;
 			}
 			inputtxt = accum+inputtxt.substring(lastIndex);
@@ -12956,8 +12956,9 @@ Current version indicated by LITEVER below.
 			documentdb_searchrange = 300;
 			documentdb_chunksize = 800;
 			documentdb_data = "";
-			new_randomness_seed(); 
 		}
+		new_randomness_seed();
+		localsettings.inject_randomness_seed = document.getElementById("inject_randomness_seed").value;
 		warn_unsaved = false;
 		last_used_saveslot = -1;
 		show_corpo_leftpanel(false);
@@ -12989,8 +12990,7 @@ Current version indicated by LITEVER below.
 
 	function new_randomness_seed()
 	{
-		localsettings.inject_randomness_seed = Math.floor(Math.random() * Math.pow(2,32));
-		document.getElementById("inject_randomness_seed").value = localsettings.inject_randomness_seed;
+		document.getElementById("inject_randomness_seed").value = Math.floor(Math.random() * Math.pow(2,32));
 	}
 
 	function btn_editmode()
@@ -14839,6 +14839,8 @@ Current version indicated by LITEVER below.
 			//only do this processing if memory or anote is not blank
 			if (truncated_memory.length > 0 || current_anote.length > 0)
 			{
+				truncated_memory = replace_placeholders(truncated_memory,false,false,false);
+				truncated_anote = replace_placeholders(truncated_anote,false,false,false);
 				if(!is_using_kcpp_with_added_memory())
 				{
 					let augmented_len = truncated_memory.length + truncated_context.length + truncated_anote.length;
@@ -14872,8 +14874,7 @@ Current version indicated by LITEVER below.
 				}
 			}
 
-			truncated_memory = replace_placeholders(truncated_memory,isgametext=false);
-			truncated_context = replace_placeholders(truncated_context,isgametext=true);
+			truncated_context = replace_placeholders(truncated_context,false,false,true);
 
 			if(is_using_kcpp_with_added_memory())
 			{

--- a/index.html
+++ b/index.html
@@ -4295,38 +4295,6 @@ Current version indicated by LITEVER below.
 		text = text.replace(/\{\{\[SYSTEM\]\}\}/g, "").replace(/\{\{\[SYSTEM_END\]\}\}/g, "");
 		return text;
 	}
-
-	function inject_randomness(text,onlystable=true)
-	{
-		//Implements SillyTavern's PickReplace and DiceRoll macros, for compatibility with existing cards
-
-		replacemacro = onlystable ? "pick" : "(?:pick|random)"
-		rollmacro = onlystable ? "toss" : "(?:roll|toss)"
-
-		text = text.replace(new RegExp("{{"+replacemacro+"\s?::?([^}]+)}}","gi"), function (m, listString) {
-			const list = listString.includes('::') ? listString.split('::') : listString.replace(/\\,/g, '{{COMMA}}').split(',').map(item => item.trim().replace(/{{COMMA}}/g, ','));
-			return (list.length===0 ? '' : list[Math.floor(Math.random()*list.length)]);
-		});
-
-		text = text.replace(new RegExp("{{"+rollmacro+"\s?:?:?([^}]+)}}","gi"), function (m, matchValue){
-			let formula = matchValue.trim();
-			if (/^\d+$/.test(formula)){ formula = "1d${formula}"; }
-			pieces = formula.match(/^([1-9]\d*)?d([1-9]\d*)([x*\u00D7][\d.]+)?([+-][\d.]+)?$/i);
-			if (!pieces) {
-				return "";
-			}
-			var total = 0;
-			for (let a = 0; a < ((pieces[1]-0)||1); ++a) {
-				total += 1+Math.floor(Math.random()*pieces[2]);
-			}
-			total *= pieces[3] ? parseFloat(pieces[3].substring(1)) : 1
-			total += pieces[4] ? parseFloat(pieces[4]) : 0;
-			return String(total);
-		});
-
-		return text;
-	}
-
 	function replace_search_placeholders(text,isstorage=false) {
 
 		// Remove any instruct tags as needed to ensure a more accurate search
@@ -14453,7 +14421,7 @@ Current version indicated by LITEVER below.
 					}
 				}
 			}
-			
+
 			let max_allowed_characters = getMaxAllowedCharacters(truncated_context, maxctxlen, maxgenamt);
 
 			//for adventure mode, inject hidden context, even more if there's nothing in memory


### PR DESCRIPTION
The UI currently offers a simple dice mechanic "Action (Roll)" to inject randomness into the user's query, but there is no way for users to control the output format in the style of [SillyTavern's macros](https://docs.sillytavern.app/usage/core-concepts/macros/#general-macros) such as `pick`, `random`, and `roll`.
This PR adds support for these three macros as a togglable option in the Format Menu (called "Randomizing Tags", but I'm not picky about the name). For compatibility with existing SillyTavern cards that make use of these macros, I've stuck to their syntax and [implementation](https://github.com/SillyTavern/SillyTavern/blob/release/public/scripts/macros.js), though I did take the chance to extend the dice notation slightly.

I had to think about where to replace these macros when they appear in the AI's memory or first message (such as when importing a card). I've put them at the end of `confirm_memory()`, meaning that they get updated along with the rest of the Context data, but there might be a better place for this.