### PR TITLE
feat: enhance word search functionality with n-gram parsing to match …

### DIFF
--- a/index.html
+++ b/index.html
@@ -22782,7 +22782,9 @@ Current version indicated by LITEVER below.
             let count = candidateItems[i][1];
             const btn = document.createElement("div");
             btn.style.border = "1px solid #646464";
-            btn.innerHTML = `<a href="#" id="id-candidate-${i}-nth" aria-label="id-candidate-${i}-nth">
+            btn.id = `id-div-candidate-${i}-nth`
+            btn.setAttribute("aria-label", `id-div-candidate-${i}-nth`)
+            btn.innerHTML = `<a href="#" id="id-a-candidate-${i}-nth" aria-label="id-a-candidate-${i}-nth">
                 <span class="color_wordsearch_surrounding" id="id-key-count-${i}-nth" aria-label="id-key-count-${i}-nth">${key} (${count})</span>
             </a>`;
             let searchstr = key;
@@ -22872,6 +22874,8 @@ Current version indicated by LITEVER below.
         matchRanges.forEach(({ range, preview }, i) => {
             const btn = document.createElement("div");
             btn.style.border = "1px solid #646464";
+            btn.id = `id-div-${idParent}-range-${i}-nth`
+            btn.setAttribute("aria-label", `id-div-${idParent}-range-${i}-nth`)
             let nearbytext = extract_surrounding_text(range, 8);
             btn.innerHTML = `<a href="#" id="id-${idParent}-range-${i}-nth" aria-label="id-${idParent}-range-${i}-nth">
                 <span id="id-${idParent}-wordsearch-result-before-${i}-nth" aria-label="id-${idParent}-wordsearch-result-before-${i}-nth" class="color_wordsearch_surrounding">${nearbytext.before}</span>
@@ -23029,7 +23033,7 @@ Current version indicated by LITEVER below.
 						<option value="1">Alphabetical</option>
 					</select>
 					</div>
-					<div id="wordsearch_results" style="height:calc(100% - 98px);overflow-y: auto;"></div>
+					<div id="wordsearch_results" aria-label="wordsearch_results" style="height:calc(100% - 98px);overflow-y: auto;"></div>
 				</div>
 			</div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -13919,6 +13919,10 @@ Current version indicated by LITEVER below.
 			}
 		}
 		render_gametext(false);
+        /* My Ghost Writer: this will parse again the text because of edit mode toggle */
+        if (localsettings.wordsearch_enabled) {
+            trigger_wordsearch_candidates()
+        }
 	}
 	function exit_editmode()
 	{
@@ -22696,187 +22700,207 @@ Current version indicated by LITEVER below.
 	});
 
 	/** Inspired by My Ghost Writer from trincadev - https://github.com/trincadev/my_ghost_writer */
-	//scan through full context to ngram a possible set of candidates
-	function trigger_wordsearch_candidates() {
-		const searchBox = document.getElementById("wordsearch_input");
-		const resultsContainer = document.getElementById("wordsearch_results");
-		const sortByFreq = document.getElementById("wordsearch_sort").value=="0";
-		const query = searchBox.value.trim();
-		resultsContainer.innerHTML = "";
+    // ES6-compatible regex for words with Latin letters (with diacritics), digits, apostrophes, hyphens, still to improve
+    const WORD_REGEX = /[A-Za-zÀ-ÖØ-öø-ÿ0-9"'-’]+/g;
 
-		let ngramParser = function (text, n) {
-			const words = text.split(/\s+/).filter(word => word.length > 0);
-			const ngrams = {};
-			for (let i = 0; i <= words.length - n; i++) {
-				const ngram = words.slice(i, i + n).join(' ');
-				if (ngrams[ngram]) {
-					ngrams[ngram]++;
-				} else {
-					ngrams[ngram] = 1;
-				}
-			}
-			const sortedNgrams = Object.entries(ngrams).sort((a, b) => b[1] - a[1]);
-			return sortedNgrams.map(entry => ({ ng: entry[0], cnt: entry[1] }));
-		}
-
-		let prepare_candidates_from_text = function(query) {
-			const fullgametext = concat_gametext(true, "").toLowerCase();
-			let querylc = query.toLowerCase();
-			let candidateDict = {};
-			if(querylc!="")
-			{
-				let basecount = (fullgametext.split(querylc).length - 1); //count of the pure substring
-				candidateDict[query] = basecount;
-			}
-
-			for(let i=1;i<=3;++i) //ngram of 3
-			{
-				let res = ngramParser(fullgametext,i);
-				if(querylc!="")
-				{
-					res = res.filter(x=>x.ng.toLowerCase().includes(querylc));
-				}
-				let lim = Math.min(res.length,250);
-				for(let j=0;j<lim;++j)
-				{
-					if (!candidateDict[res[j].ng]) {
-						candidateDict[res[j].ng] = res[j].cnt;
-					} else {
-						candidateDict[res[j].ng] = Math.max(candidateDict[res[j].ng], res[j].cnt);
-					}
-				}
-			}
-			return candidateDict;
-		}
-
-		let candidateDict = prepare_candidates_from_text(query);
-		var candidateItems = Object.keys(candidateDict).map(function(key) {
-			return [key, candidateDict[key]];
-		});
-
-		if(sortByFreq)
-		{
-			candidateItems.sort(function(first, second) {
-				return second[1] - first[1];
-			});
-		}else
-		{
-			//sort alphabetically
-			candidateItems.sort(function(first, second) {
-				if (first[0] < second[0]) {
-					return -1;
-				}
-				if (first[0] > second[0]) {
-					return 1;
-				}
-				return 0;
-			});
-
-		}
-
-
-		for(let i=0;i<candidateItems.length;++i)
-		{
-			let key = candidateItems[i][0];
-			let count = candidateItems[i][1];
-			const btn = document.createElement("div");
-			btn.style.border = "1px solid #646464";
-			btn.innerHTML = `<a href="#"><span class="color_wordsearch_surrounding">${key} (${count}+)</span></a>`;
-			let searchstr = key;
-			btn.onclick = () => {
-				trigger_wordsearch_results(searchstr);
-			};
-			resultsContainer.appendChild(btn);
-		}
-	}
-	function trigger_wordsearch_candidates_key()
-	{
-		if (event.key === 'Enter') {
-			trigger_wordsearch_candidates();
+    // N-gram parser: generates n-grams from an array of words
+    function ngramParser(words, n) {
+        const ngrams = {};
+        for (let i = 0; i <= words.length - n; i++) {
+            const ngram = words.slice(i, i + n).join(' ');
+            ngrams[ngram] = (ngrams[ngram] || 0) + 1;
         }
-	}
+        return ngrams;
+    }
 
-	function trigger_wordsearch_results(query) {
-		const resultsContainer = document.getElementById("wordsearch_results");
-		const gametext = document.getElementById("gametext");
-		query = query.trim();
-		resultsContainer.innerHTML = "";
-		if (!query) return;
+    function prepare_candidates_from_text(query, textrows, maxNgram = 3, perLineLimit = 250) {
+        let candidateDict = {};
+        const querylc = query.toLowerCase();
 
-		let extract_surrounding_text = function(range, contextLength) {
-			const textNode = range.startContainer;
-			if (textNode.nodeType !== Node.TEXT_NODE) return;
-			const textContent = textNode.textContent;
-			const startOffset = range.startOffset;
-			const endOffset = range.endOffset;
-			// Compute raw bounds
-			let start = Math.max(0, startOffset - contextLength);
-			let end = Math.min(textContent.length, endOffset + contextLength);
-			// Clamp to word boundaries
-			start = textContent.lastIndexOf(' ', start);
-			end = textContent.indexOf(' ', end);
-			if (start === -1) start = 0;
-			if (end === -1) end = textContent.length;
-			const before = textContent.slice(start, startOffset);
-			const middle = textContent.slice(startOffset, endOffset);
-			const after = textContent.slice(endOffset,end);
-			return {"before":before, "middle":middle, "after":after, "full":`${before}${middle}${after}`};
-		}
+        // For each line, generate n-grams and count
+        for (let l = 0; l < textrows.length; ++l) {
+            const line = textrows[l].toLowerCase();
+            const words = line.match(WORD_REGEX) || [];
+            for (let n = 1; n <= maxNgram; ++n) {
+                const ngrams = ngramParser(words, n);
+                // Sort and limit per line
+                const sortedNgrams = Object.entries(ngrams).sort((a, b) => b[1] - a[1]);
+                const lim = Math.min(sortedNgrams.length, perLineLimit);
+                for (let j = 0; j < lim; ++j) {
+                    const [ng, cnt] = sortedNgrams[j];
+                    // Include only n-grams that contain the query substring (case-insensitive, anywhere)
+                    if (querylc && !ng.includes(querylc)) continue;
+                    candidateDict[ng] = (candidateDict[ng] || 0) + cnt;
+                }
+            }
+        }
+        return candidateDict;
+    }
+	
+	function trigger_wordsearch_candidates() {
+        const searchBox = document.getElementById("wordsearch_input");
+        const resultsContainer = document.getElementById("wordsearch_results");
+        const sortByFreq = document.getElementById("wordsearch_sort").value === "0";
+        const query = searchBox.value.trim().toLowerCase();
+        resultsContainer.innerHTML = "";
 
-		let search_text_for_strings = function(query) { //search text nodes for all instances of query
-			const gametext = document.getElementById("gametext");
-			let matchRanges = [];
-			const walker = document.createTreeWalker(gametext, NodeFilter.SHOW_TEXT, null, false);
+        // Get all text rows (lines/paragraphs)
+        const gametext = document.getElementById("gametext");
+        const textrows = Array.from(gametext.childNodes)
+            .filter(node => node.nodeType === Node.TEXT_NODE || node.nodeType === Node.ELEMENT_NODE)
+            .map(node => node.textContent);
 
-			while (walker.nextNode()) {
-				const node = walker.currentNode;
-				const text = node.nodeValue;
-				let idx = 0;
-				while ((idx = text.toLowerCase().indexOf(query.toLowerCase(), idx)) !== -1) {
-				const range = document.createRange();
-				range.setStart(node, idx);
-				range.setEnd(node, idx + query.length);
-				matchRanges.push({ range, preview: text.substr(idx, query.length) });
-				idx += query.length;
-				}
-			}
-			return matchRanges;
-		}
+        // --- Efficient n-gram counting ---
+        const maxNgram = 3;
+        const ngramCounts = {};
+        for (let l = 0; l < textrows.length; ++l) {
+            const line = textrows[l];
+            const words = (line.match(WORD_REGEX) || []);
+            for (let n = 1; n <= maxNgram; ++n) {
+                for (let i = 0; i <= words.length - n; i++) {
+                    // Lowercase the ngram for normalization, but keep apostrophes/hyphens
+                    const ngram = words.slice(i, i + n).join(' ').toLowerCase();
+                    ngramCounts[ngram] = (ngramCounts[ngram] || 0) + 1;
+                }
+            }
+        }
 
-		let matchRanges = search_text_for_strings(query);
+        // --- Substring Filter (case-insensitive, all n-grams are lowercase) ---
+        let candidateItems = Object.entries(ngramCounts)
+            .filter(([ng, count]) => (!query || ng.includes(query)) && count > 0);
 
-		const topper = document.createElement("div");
-		topper.style.border = "1px solid #646464";
-		topper.innerText = `${matchRanges.length} results`;
-		resultsContainer.appendChild(topper);
-		matchRanges.forEach(({ range, preview }, i) => {
-			const btn = document.createElement("div");
-			btn.style.border = "1px solid #646464";
-			let nearbytext = extract_surrounding_text(range, 8);  //8 chars clamped to word bounds
-			btn.innerHTML = `<a href="#"><span class="color_wordsearch_surrounding">${nearbytext.before}</span><span class="color_wordsearch_target">${nearbytext.middle}</span><span class="color_wordsearch_surrounding">${nearbytext.after}</span></a>`;
-			btn.onclick = () => {
-				const sel = window.getSelection();
-				sel.removeAllRanges();
-				sel.addRange(range);
+        // Sort
+        if (sortByFreq) {
+            candidateItems.sort((a, b) => b[1] - a[1]);
+        } else {
+            candidateItems.sort((a, b) => a[0].localeCompare(b[0]));
+        }
 
-				// Scroll the container
-				const rect = range.getBoundingClientRect();
-				const containerRect = gametext.getBoundingClientRect();
-				if (rect.top < containerRect.top || rect.bottom > containerRect.bottom) {
-					if (range.startContainer && range.startContainer.nodeType === Node.TEXT_NODE) {
-						const span = document.createElement("span");
-						span.style.display = "inline";
-						span.style.background = "transparent";
-						span.id = "temp-scroll-target";
-						range.insertNode(span); // Insert a temporary marker, then scroll to it
-						document.querySelector("#temp-scroll-target").scrollIntoView({ behavior: "smooth", block: "center" });
-						span.remove(); //remove temp marker
-					}
-				}
-			};
-			resultsContainer.appendChild(btn);
-		});
-	}
+        // Display results
+        for (let i = 0; i < candidateItems.length; ++i) {
+            let key = candidateItems[i][0];
+            let count = candidateItems[i][1];
+            const btn = document.createElement("div");
+            btn.style.border = "1px solid #646464";
+            btn.innerHTML = `<a href="#" id="id-candidate-${i}-nth" aria-label="id-candidate-${i}-nth">
+                <span class="color_wordsearch_surrounding" id="id-key-count-${i}-nth" aria-label="id-key-count-${i}-nth">${key} (${count})</span>
+            </a>`;
+            let searchstr = key;
+            btn.onclick = () => {
+                trigger_wordsearch_results(searchstr, i);
+            };
+            resultsContainer.appendChild(btn);
+        }
+        // Add count feedback
+        const countElem = document.createElement("span");
+        countElem.id = "wordsearch_candidates_count";
+        countElem.setAttribute("aria-label", "wordsearch_candidates_count");
+        countElem.textContent = `${candidateItems.length} result(s) found`;
+        resultsContainer.prepend(countElem);
+    }
+
+    function trigger_wordsearch_candidates_key(event) {
+        if (event.key === 'Enter') {
+            trigger_wordsearch_candidates();
+        }
+    }
+
+    // DOM-based, robust search for exact word/n-gram matches
+    function trigger_wordsearch_results(query, idParent) {
+        const resultsContainer = document.getElementById("wordsearch_results");
+        const gametext = document.getElementById("gametext");
+        query = query.trim();
+        resultsContainer.innerHTML = "";
+        if (!query) return;
+
+        const queryWords = query.match(WORD_REGEX) || [];
+        if (queryWords.length === 0) return;
+
+        // Helper: extract context for preview
+        function extract_surrounding_text(range, contextLength) {
+            const textNode = range.startContainer;
+            if (textNode.nodeType !== Node.TEXT_NODE) return;
+            const textContent = textNode.textContent;
+            const startOffset = range.startOffset;
+            const endOffset = range.endOffset;
+            let start = Math.max(0, startOffset - contextLength);
+            let end = Math.min(textContent.length, endOffset + contextLength);
+            start = textContent.lastIndexOf(' ', start);
+            end = textContent.indexOf(' ', end);
+            if (start === -1) start = 0;
+            if (end === -1) end = textContent.length;
+            const before = textContent.slice(start, startOffset);
+            const middle = textContent.slice(startOffset, endOffset);
+            const after = textContent.slice(endOffset, end);
+            return {"before": before, "middle": middle, "after": after, "full": `${before}${middle}${after}`};
+        }
+
+        // Search for exact matches in the DOM
+        function search_text_for_strings(queryWords) {
+            let matchRanges = [];
+            const walker = document.createTreeWalker(gametext, NodeFilter.SHOW_TEXT, null, false);
+            while (walker.nextNode()) {
+                const node = walker.currentNode;
+                const text = node.nodeValue;
+                let words = [];
+                let match;
+                while ((match = WORD_REGEX.exec(text)) !== null) {
+                    words.push({ word: match[0], index: match.index });
+                }
+                for (let i = 0; i <= words.length - queryWords.length; i++) {
+                    let windowWords = words.slice(i, i + queryWords.length);
+                    // Compare as lowercased, exact match
+                    if (windowWords.map(w => w.word.toLowerCase()).join(' ') === queryWords.map(w => w.toLowerCase()).join(' ')) {
+                        const startIdx = windowWords[0].index;
+                        const endIdx = windowWords[windowWords.length - 1].index + windowWords[windowWords.length - 1].word.length;
+                        const range = document.createRange();
+                        range.setStart(node, startIdx);
+                        range.setEnd(node, endIdx);
+                        matchRanges.push({ range, preview: text.slice(startIdx, endIdx) });
+                    }
+                }
+            }
+            return matchRanges;
+        }
+
+        let matchRanges = search_text_for_strings(queryWords);
+
+        const topper = document.createElement("div");
+        topper.style.border = "1px solid #646464";
+        topper.innerText = `${matchRanges.length} results`;
+        resultsContainer.appendChild(topper);
+        matchRanges.forEach(({ range, preview }, i) => {
+            const btn = document.createElement("div");
+            btn.style.border = "1px solid #646464";
+            let nearbytext = extract_surrounding_text(range, 8);
+            btn.innerHTML = `<a href="#" id="id-${idParent}-range-${i}-nth" aria-label="id-${idParent}-range-${i}-nth">
+                <span id="id-${idParent}-wordsearch-result-before-${i}-nth" aria-label="id-${idParent}-wordsearch-result-before-${i}-nth" class="color_wordsearch_surrounding">${nearbytext.before}</span>
+                <span id="id-${idParent}-wordsearch-result-target-${i}-nth" aria-label="id-${idParent}-wordsearch-result-target-${i}-nth" class="color_wordsearch_target">${nearbytext.middle}</span>
+                <span id="id-${idParent}-wordsearch-result-after-${i}-nth" aria-label="id-${idParent}-wordsearch-result-after-${i}-nth" class="color_wordsearch_surrounding">${nearbytext.after}</span>
+            </a>`;
+            btn.onclick = () => {
+                const sel = window.getSelection();
+                sel.removeAllRanges();
+                sel.addRange(range);
+
+                // Scroll the container
+                const rect = range.getBoundingClientRect();
+                const containerRect = gametext.getBoundingClientRect();
+                if (rect.top < containerRect.top || rect.bottom > containerRect.bottom) {
+                    if (range.startContainer && range.startContainer.nodeType === Node.TEXT_NODE) {
+                        const span = document.createElement("span");
+                        span.style.display = "inline";
+                        span.style.background = "transparent";
+                        span.id = "temp-scroll-target";
+                        range.insertNode(span);
+                        document.querySelector("#temp-scroll-target").scrollIntoView({ behavior: "smooth", block: "center" });
+                        span.remove();
+                    }
+                }
+            };
+            resultsContainer.appendChild(btn);
+        });
+    }
 	</script>
 
 </head>
@@ -22924,7 +22948,7 @@ Current version indicated by LITEVER below.
 		<div id="outerbodybg"></div>
 		<div id="topmenu" class="topmenu">
 			<div style="width: 100%;">
-				<button title="Main Menu Options" class="navtoggler mainnav" type="button" onclick="toggleTopNav()">
+                <button title="Main Menu Options" class="navtoggler mainnav" type="button" onclick="toggleTopNav()" id="id-mobile-main-menu-options" aria-label="id-mobile-main-menu-options">
 					<span class="navbar-button-bar"></span>
 					<span class="navbar-button-bar"></span>
 					<span class="navbar-button-bar"></span>
@@ -22995,7 +23019,7 @@ Current version indicated by LITEVER below.
 				</span>
 				<div class="hidden" id="wordsearch_panel" style="flex:250px">
 					<div style="display:flex; padding:6px">
-					<input title="Word Search Input" class="form-control menuinput_inline" style="width: calc(100% - 34px); margin-right:2px;" type="text" placeholder="WordSearch" value="" onkeyup="trigger_wordsearch_candidates_key();" id="wordsearch_input">
+					<input title="Word Search Input" class="form-control menuinput_inline" style="width: calc(100% - 34px); margin-right:2px;" type="search" placeholder="WordSearch" value="" onkeyup="trigger_wordsearch_candidates_key(event);" id="wordsearch_input">
 					<button title="Perform WordSearch" type="button" class="btn btn-primary" style="width:30px;padding:4px 4px;" onclick="trigger_wordsearch_candidates();">🔎</button>
 					</div>
 					<div style="display:flex; padding:6px">

--- a/index.html
+++ b/index.html
@@ -23242,7 +23242,7 @@ Current version indicated by LITEVER below.
 				<div class="hidden" id="wordsearch_panel" style="flex:250px">
 					<div style="display:flex; padding:6px">
 					<input title="Word Search Input" class="form-control menuinput_inline" style="width: calc(100% - 34px); margin-right:2px;" type="search" placeholder="WordSearch" value="" onkeyup="trigger_wordsearch_candidates_key(event);" id="wordsearch_input">
-					<button title="Perform WordSearch" type="button" class="btn btn-primary" style="width:30px;padding:4px 4px;" onclick="trigger_wordsearch_candidates();">🔎</button>
+					<button title="Perform WordSearch" type="button" class="btn btn-primary" style="width:30px;padding:4px 4px;" onclick="trigger_wordsearch_candidates();" id="id-perform-wordsearch" aria-label="id-perform-wordsearch">🔎</button>
 					</div>
 					<div style="display:flex; padding:6px">
 					<p style="margin-right:6px">Sort: </p>

--- a/index.html
+++ b/index.html
@@ -22701,7 +22701,8 @@ Current version indicated by LITEVER below.
 
 	/** Inspired by My Ghost Writer from trincadev - https://github.com/trincadev/my_ghost_writer */
     // ES6-compatible regex for words with Latin letters (with diacritics), digits, apostrophes, hyphens, still to improve
-    const WORD_REGEX = /[A-Za-zÀ-ÖØ-öø-ÿ0-9"'-’]+/g;
+    const underlinedClickedUrl = "background-border-clicked"
+    const WORD_REGEX = /[A-Za-zÀ-ÖØ-öø-ÿ0-9'-’]+/g;
 
     // N-gram parser: generates n-grams from an array of words
     function ngramParser(words, n) {
@@ -22837,6 +22838,13 @@ Current version indicated by LITEVER below.
             return {"before": before, "middle": middle, "after": after, "full": `${before}${middle}${after}`};
         }
 
+        function removeClassById(oldClassName) {
+            let oldClassElement = document.getElementsByClassName(oldClassName);
+            if (oldClassElement.length > 0) {
+                oldClassElement[0].classList.remove(oldClassName);
+            }
+        }
+
         // Search for exact matches in the DOM
         function search_text_for_strings(queryWords) {
             let matchRanges = [];
@@ -22890,6 +22898,9 @@ Current version indicated by LITEVER below.
                 // Scroll the container
                 const rect = range.getBoundingClientRect();
                 const containerRect = gametext.getBoundingClientRect();
+                removeClassById(underlinedClickedUrl);
+                btn.className = underlinedClickedUrl;
+
                 if (rect.top < containerRect.top || rect.bottom > containerRect.bottom) {
                     if (range.startContainer && range.startContainer.nodeType === Node.TEXT_NODE) {
                         const span = document.createElement("span");
@@ -22907,6 +22918,12 @@ Current version indicated by LITEVER below.
     }
 	</script>
 
+    <style>
+        .background-border-clicked {
+            background: black;
+            border: 1px solid white !important;
+        }
+    </style>
 </head>
 
 <body id="outerbody" class="darkmode" onkeydown="handle_escape_button(event)" onbeforeunload="return handle_quit()">
@@ -23398,7 +23415,7 @@ Current version indicated by LITEVER below.
 							<button type="button" class="btn btn-primary" id="btn_aesthetics" onclick="openAestheticUISettingsMenu()" style="border-color: #bbbbbb; width:100%; height:30px; padding:0px 8px; margin: 3px 0 3px 0;">⚙️ Customize</button>
 							<div id="classicmodeoptions" style="margin:4px;" class="settinglabel hidden">
 							<div class="justifyleft settingsmall">WordSearch Tool <span class="helpicon">?<span class="helptext">Shows a tool that displays word frequency and locations, inspired by trincadev MyGhostWriter. Counts across newlines may be inaccurate.</span></span></div>
-							   <input title="WordSearch Tool" type="checkbox" id="wordsearch_toggle" style="margin:0px 0px 0px 0px;">
+							   <input title="WordSearch Tool" type="checkbox" id="wordsearch_toggle" style="margin:0px 0px 0px 0px;" aria-label="wordsearch_toggle">
 							</div>
 							<div id="guitypedesc" class="settingsdesctxt"></div>
 						</div>

--- a/index.html
+++ b/index.html
@@ -19370,7 +19370,7 @@ Current version indicated by LITEVER below.
 				{
 					let curr = instruct_turns[i];
 					let currmsg = curr.msg;
-					if(localsettings.instruct_has_markdown && (synchro_pending_stream==""||(i+1)<instruct_turns.length))
+					if(localsettings.instruct_has_markdown && (localsettings.render_streaming_markdown||synchro_pending_stream==""||(i+1)<instruct_turns.length))
 					{
 						//if a list has a starttag on the same line, add a newline before it
 						currmsg = currmsg.replace(/(\n[-*] .+?)(%SpcStg%)/g, "$1\n$2");

--- a/index.html
+++ b/index.html
@@ -14372,17 +14372,32 @@ Current version indicated by LITEVER below.
 		document.getElementById("addimgcontainer").classList.add("hidden");
 		document.getElementById("webcamcontainer").classList.remove("hidden");
 		const video = document.getElementById('webcamvideo');
-		if(webcamStream)
-		{
+
+		if (webcamStream) {
 			stop_webcam();
 		}
-		navigator.mediaDevices.getUserMedia({ video: true })
+
+		navigator.mediaDevices.getUserMedia({
+			video: {
+				facingMode: { exact: "environment" } // Request back camera
+			}
+		})
 		.then(stream => {
 			webcamStream = stream;
 			video.srcObject = stream;
 		})
 		.catch(err => {
 			console.error('Error accessing webcam:', err);
+
+			// Fallback: try default camera if back camera not available
+			navigator.mediaDevices.getUserMedia({ video: true })
+			.then(fallbackStream => {
+				webcamStream = fallbackStream;
+				video.srcObject = fallbackStream;
+			})
+			.catch(fallbackErr => {
+				console.error('Fallback error accessing webcam:', fallbackErr);
+			});
 		});
 	}
 	function stop_webcam()

--- a/index.html
+++ b/index.html
@@ -2206,6 +2206,18 @@ Current version indicated by LITEVER below.
 	.color_pink {
 		color: #ffbdbd;
 	}
+	.color_wordsearch_target
+	{
+		color: violet;
+		text-decoration: underline;
+		text-decoration-color: violet;
+	}
+	.color_wordsearch_surrounding
+	{
+		color: yellow;
+		text-decoration: underline;
+		text-decoration-color: yellow;
+	}
 
 	.bg_black {
 		background-color: #202020;
@@ -3367,6 +3379,7 @@ Current version indicated by LITEVER below.
 		websearch_multipass: false,
 		websearch_retain: false,
 		websearch_template: "",
+		wordsearch_enabled: false,
 
 		max_context_length: (localflag?4096:2048),
 		max_length: (localflag?512:256),
@@ -12353,6 +12366,7 @@ Current version indicated by LITEVER below.
 		document.getElementById("run_in_background").checked = run_in_background;
 		document.getElementById("auto_ctxlen").checked = localsettings.auto_ctxlen;
 		document.getElementById("auto_genamt").checked = localsettings.auto_genamt;
+		document.getElementById("wordsearch_toggle").checked = localsettings.wordsearch_enabled;
 		if(localflag)
 		{
 			document.getElementById("auto_ctxlen_panel").classList.add("hidden");
@@ -12943,6 +12957,7 @@ Current version indicated by LITEVER below.
 		localsettings.voice_langcode = document.getElementById("voice_langcode").value;
 		localsettings.auto_ctxlen = (document.getElementById("auto_ctxlen").checked ? true : false);
 		localsettings.auto_genamt = (document.getElementById("auto_genamt").checked ? true : false);
+		localsettings.wordsearch_enabled = (document.getElementById("wordsearch_toggle").checked ? true : false);
 
 		localsettings.image_styles = document.getElementById("imagestyleinput").value;
 		localsettings.image_negprompt = document.getElementById("negpromptinput").value;
@@ -13240,9 +13255,20 @@ Current version indicated by LITEVER below.
 	function toggle_uistyle()
 	{
 		//show or hide the 'Customize UI' button based on whether the Aesthetic Instruct UI Mode is active or not.
-		if (document.getElementById('gui_type').value==2) { document.getElementById('btn_aesthetics').classList.remove('hidden'); }
-		else { document.getElementById('btn_aesthetics').classList.add('hidden'); }
+		if (document.getElementById('gui_type').value == 2) {
+			document.getElementById('btn_aesthetics').classList.remove('hidden');
+		}
+		else {
+			document.getElementById('btn_aesthetics').classList.add('hidden');
+		}
 		document.getElementById("guitypedesc").innerText = get_theme_desc(document.getElementById('gui_type').value);
+
+		if (document.getElementById('gui_type').value == 0) {
+			document.getElementById('classicmodeoptions').classList.remove('hidden');
+		}
+		else {
+			document.getElementById('classicmodeoptions').classList.add('hidden');
+		}
 	}
 
 	function select_welcome_ui()
@@ -13345,8 +13371,12 @@ Current version indicated by LITEVER below.
 			document.getElementById('gui_type').value = 0;
 		}
 
-		if (document.getElementById('gui_type').value==2) { document.getElementById('btn_aesthetics').classList.remove('hidden'); }
-		else { document.getElementById('btn_aesthetics').classList.add('hidden'); }
+		if (document.getElementById('gui_type').value == 2) {
+			document.getElementById('btn_aesthetics').classList.remove('hidden');
+		}
+		else {
+			document.getElementById('btn_aesthetics').classList.add('hidden');
+		}
 
 		toggle_uistyle();
 	}
@@ -13783,6 +13813,8 @@ Current version indicated by LITEVER below.
 		document.getElementById("input_text").value = "";
 		document.getElementById("corpo_cht_inp").value = "";
 		document.getElementById("cht_inp").value = "";
+		let wsresultsContainer = document.getElementById("wordsearch_results");
+		if(wsresultsContainer){wsresultsContainer.innerHTML="";}
 		chat_resize_input();
 		image_db = {};
 		interrogation_db = {};
@@ -19792,6 +19824,14 @@ Current version indicated by LITEVER below.
 		{
 			document.getElementById("searchingtxt").classList.add("hidden");
 		}
+
+		if(localsettings.wordsearch_enabled)
+		{
+			document.getElementById("wordsearch_panel").classList.remove("hidden");
+		}else
+		{
+			document.getElementById("wordsearch_panel").classList.add("hidden");
+		}
 	}
 
 	function render_corpo_welcome()
@@ -22654,6 +22694,189 @@ Current version indicated by LITEVER below.
 			return searchResults;
 		}
 	});
+
+	/** Inspired by My Ghost Writer from trincadev - https://github.com/trincadev/my_ghost_writer */
+	//scan through full context to ngram a possible set of candidates
+	function trigger_wordsearch_candidates() {
+		const searchBox = document.getElementById("wordsearch_input");
+		const resultsContainer = document.getElementById("wordsearch_results");
+		const sortByFreq = document.getElementById("wordsearch_sort").value=="0";
+		const query = searchBox.value.trim();
+		resultsContainer.innerHTML = "";
+
+		let ngramParser = function (text, n) {
+			const words = text.split(/\s+/).filter(word => word.length > 0);
+			const ngrams = {};
+			for (let i = 0; i <= words.length - n; i++) {
+				const ngram = words.slice(i, i + n).join(' ');
+				if (ngrams[ngram]) {
+					ngrams[ngram]++;
+				} else {
+					ngrams[ngram] = 1;
+				}
+			}
+			const sortedNgrams = Object.entries(ngrams).sort((a, b) => b[1] - a[1]);
+			return sortedNgrams.map(entry => ({ ng: entry[0], cnt: entry[1] }));
+		}
+
+		let prepare_candidates_from_text = function(query) {
+			const fullgametext = concat_gametext(true, "").toLowerCase();
+			let querylc = query.toLowerCase();
+			let candidateDict = {};
+			if(querylc!="")
+			{
+				let basecount = (fullgametext.split(querylc).length - 1); //count of the pure substring
+				candidateDict[query] = basecount;
+			}
+
+			for(let i=1;i<=3;++i) //ngram of 3
+			{
+				let res = ngramParser(fullgametext,i);
+				if(querylc!="")
+				{
+					res = res.filter(x=>x.ng.toLowerCase().includes(querylc));
+				}
+				let lim = Math.min(res.length,250);
+				for(let j=0;j<lim;++j)
+				{
+					if (!candidateDict[res[j].ng]) {
+						candidateDict[res[j].ng] = res[j].cnt;
+					} else {
+						candidateDict[res[j].ng] = Math.max(candidateDict[res[j].ng], res[j].cnt);
+					}
+				}
+			}
+			return candidateDict;
+		}
+
+		let candidateDict = prepare_candidates_from_text(query);
+		var candidateItems = Object.keys(candidateDict).map(function(key) {
+			return [key, candidateDict[key]];
+		});
+
+		if(sortByFreq)
+		{
+			candidateItems.sort(function(first, second) {
+				return second[1] - first[1];
+			});
+		}else
+		{
+			//sort alphabetically
+			candidateItems.sort(function(first, second) {
+				if (first[0] < second[0]) {
+					return -1;
+				}
+				if (first[0] > second[0]) {
+					return 1;
+				}
+				return 0;
+			});
+
+		}
+
+
+		for(let i=0;i<candidateItems.length;++i)
+		{
+			let key = candidateItems[i][0];
+			let count = candidateItems[i][1];
+			const btn = document.createElement("div");
+			btn.style.border = "1px solid #646464";
+			btn.innerHTML = `<a href="#"><span class="color_wordsearch_surrounding">${key} (${count}+)</span></a>`;
+			let searchstr = key;
+			btn.onclick = () => {
+				trigger_wordsearch_results(searchstr);
+			};
+			resultsContainer.appendChild(btn);
+		}
+	}
+	function trigger_wordsearch_candidates_key()
+	{
+		if (event.key === 'Enter') {
+			trigger_wordsearch_candidates();
+        }
+	}
+
+	function trigger_wordsearch_results(query) {
+		const resultsContainer = document.getElementById("wordsearch_results");
+		const gametext = document.getElementById("gametext");
+		query = query.trim();
+		resultsContainer.innerHTML = "";
+		if (!query) return;
+
+		let extract_surrounding_text = function(range, contextLength) {
+			const textNode = range.startContainer;
+			if (textNode.nodeType !== Node.TEXT_NODE) return;
+			const textContent = textNode.textContent;
+			const startOffset = range.startOffset;
+			const endOffset = range.endOffset;
+			// Compute raw bounds
+			let start = Math.max(0, startOffset - contextLength);
+			let end = Math.min(textContent.length, endOffset + contextLength);
+			// Clamp to word boundaries
+			start = textContent.lastIndexOf(' ', start);
+			end = textContent.indexOf(' ', end);
+			if (start === -1) start = 0;
+			if (end === -1) end = textContent.length;
+			const before = textContent.slice(start, startOffset);
+			const middle = textContent.slice(startOffset, endOffset);
+			const after = textContent.slice(endOffset,end);
+			return {"before":before, "middle":middle, "after":after, "full":`${before}${middle}${after}`};
+		}
+
+		let search_text_for_strings = function(query) { //search text nodes for all instances of query
+			const gametext = document.getElementById("gametext");
+			let matchRanges = [];
+			const walker = document.createTreeWalker(gametext, NodeFilter.SHOW_TEXT, null, false);
+
+			while (walker.nextNode()) {
+				const node = walker.currentNode;
+				const text = node.nodeValue;
+				let idx = 0;
+				while ((idx = text.toLowerCase().indexOf(query.toLowerCase(), idx)) !== -1) {
+				const range = document.createRange();
+				range.setStart(node, idx);
+				range.setEnd(node, idx + query.length);
+				matchRanges.push({ range, preview: text.substr(idx, query.length) });
+				idx += query.length;
+				}
+			}
+			return matchRanges;
+		}
+
+		let matchRanges = search_text_for_strings(query);
+
+		const topper = document.createElement("div");
+		topper.style.border = "1px solid #646464";
+		topper.innerText = `${matchRanges.length} results`;
+		resultsContainer.appendChild(topper);
+		matchRanges.forEach(({ range, preview }, i) => {
+			const btn = document.createElement("div");
+			btn.style.border = "1px solid #646464";
+			let nearbytext = extract_surrounding_text(range, 8);  //8 chars clamped to word bounds
+			btn.innerHTML = `<a href="#"><span class="color_wordsearch_surrounding">${nearbytext.before}</span><span class="color_wordsearch_target">${nearbytext.middle}</span><span class="color_wordsearch_surrounding">${nearbytext.after}</span></a>`;
+			btn.onclick = () => {
+				const sel = window.getSelection();
+				sel.removeAllRanges();
+				sel.addRange(range);
+
+				// Scroll the container
+				const rect = range.getBoundingClientRect();
+				const containerRect = gametext.getBoundingClientRect();
+				if (rect.top < containerRect.top || rect.bottom > containerRect.bottom) {
+					if (range.startContainer && range.startContainer.nodeType === Node.TEXT_NODE) {
+						const span = document.createElement("span");
+						span.style.display = "inline";
+						span.style.background = "transparent";
+						span.id = "temp-scroll-target";
+						range.insertNode(span); // Insert a temporary marker, then scroll to it
+						document.querySelector("#temp-scroll-target").scrollIntoView({ behavior: "smooth", block: "center" });
+						span.remove(); //remove temp marker
+					}
+				}
+			};
+			resultsContainer.appendChild(btn);
+		});
+	}
 	</script>
 
 </head>
@@ -22770,6 +22993,20 @@ Current version indicated by LITEVER below.
 					<p id="tempgtloadtxt">Loading...</p>
 					<noscript><style>#tempgtloadtxt { display: none; } #gametext { white-space: normal!important; }</style><p>Sorry, KoboldAI Lite requires Javascript to function.</p></noscript>
 				</span>
+				<div class="hidden" id="wordsearch_panel" style="flex:250px">
+					<div style="display:flex; padding:6px">
+					<input title="Word Search Input" class="form-control menuinput_inline" style="width: calc(100% - 34px); margin-right:2px;" type="text" placeholder="WordSearch" value="" onkeyup="trigger_wordsearch_candidates_key();" id="wordsearch_input">
+					<button title="Perform WordSearch" type="button" class="btn btn-primary" style="width:30px;padding:4px 4px;" onclick="trigger_wordsearch_candidates();">🔎</button>
+					</div>
+					<div style="display:flex; padding:6px">
+					<p style="margin-right:6px">Sort: </p>
+					<select title="Sort" style="padding:2px; font-size:14px; height:24px; width: calc(100% - 50px);" class="form-control" id="wordsearch_sort">
+						<option value="0">Frequency</option>
+						<option value="1">Alphabetical</option>
+					</select>
+					</div>
+					<div id="wordsearch_results" style="height:calc(100% - 98px);overflow-y: auto;"></div>
+				</div>
 			</div>
 		</div>
 
@@ -22883,6 +23120,8 @@ Current version indicated by LITEVER below.
 				</div>
 			</div>
 		</div>
+
+
 	</div>
 
 	<div class="popupcontainer flex hidden" id="memorycontainer">
@@ -23129,6 +23368,10 @@ Current version indicated by LITEVER below.
 								<option id="uipicker_corpo" value="3">Corpo Theme</option>
 							</select>
 							<button type="button" class="btn btn-primary" id="btn_aesthetics" onclick="openAestheticUISettingsMenu()" style="border-color: #bbbbbb; width:100%; height:30px; padding:0px 8px; margin: 3px 0 3px 0;">⚙️ Customize</button>
+							<div id="classicmodeoptions" style="margin:4px;" class="settinglabel hidden">
+							<div class="justifyleft settingsmall">WordSearch Tool <span class="helpicon">?<span class="helptext">Shows a tool that displays word frequency and locations, inspired by trincadev MyGhostWriter. Counts across newlines may be inaccurate.</span></span></div>
+							   <input title="WordSearch Tool" type="checkbox" id="wordsearch_toggle" style="margin:0px 0px 0px 0px;">
+							</div>
 							<div id="guitypedesc" class="settingsdesctxt"></div>
 						</div>
 					</div>

--- a/index.html
+++ b/index.html
@@ -22976,6 +22976,37 @@ Current version indicated by LITEVER below.
         }
     }
 
+    function scrollToGivenPoint(editorElement, yClientOffset, negativeMultiplierFontSize = 3) {
+        const editorComputedStyle = window.getComputedStyle(editorElement)
+        const fontSize = parseInt(editorComputedStyle.getPropertyValue("font-size"), 10)
+        const negativeOffset = fontSize * negativeMultiplierFontSize
+        const scrollHeight = editorElement.scrollHeight
+        if (yClientOffset < (scrollHeight - negativeOffset)) {
+            yClientOffset -= negativeOffset
+        }
+        editorElement.scrollTo(0, yClientOffset, {behavior: "smooth" });
+    }
+    function getOffsetsWithElement(el) {
+        return {top: el.offsetTop, height: el.offsetHeight}
+    }
+    function getBoundingClientRect(el) {
+        let bounds = el.getBoundingClientRect();
+        return {x: bounds.left, y: bounds.y, bottom: bounds.bottom, top: bounds.top};
+    }
+    function scrollToCaret(range, editorFieldLabel) {
+        const editorElement = document.getElementById(editorFieldLabel)
+        editorElement.scrollTo(0, 0) // workaround: first reset the scroll position moving it at editorElement beginning
+        editorElement.focus();
+        const offsetsEditor = getOffsetsWithElement(editorElement)
+        const yBase = offsetsEditor.top
+        const height = offsetsEditor.height
+
+        const {y} = getBoundingClientRect(range)
+        // scroll to the top of the current viewport minus half the current visible height
+        const yClientOffset = y - yBase - parseInt(height / 2)
+        scrollToGivenPoint(editorElement, yClientOffset)
+    }
+
     // DOM-based, robust search for exact word/n-gram matches
     function trigger_wordsearch_results(query, idParent) {
         const resultsContainer = document.getElementById("wordsearch_results");
@@ -23062,23 +23093,25 @@ Current version indicated by LITEVER below.
                 const sel = window.getSelection();
                 sel.removeAllRanges();
                 sel.addRange(range);
-
-                // Scroll the container
-                const rect = range.getBoundingClientRect();
-                const containerRect = gametext.getBoundingClientRect();
                 removeClassById(underlinedClickedUrl);
                 btn.className = underlinedClickedUrl;
-
-                if (rect.top < containerRect.top || rect.bottom > containerRect.bottom) {
-                    if (range.startContainer && range.startContainer.nodeType === Node.TEXT_NODE) {
-                        const span = document.createElement("span");
-                        span.style.display = "inline";
-                        span.style.background = "transparent";
-                        span.id = "temp-scroll-target";
-                        range.insertNode(span);
-                        document.querySelector("#temp-scroll-target").scrollIntoView({ behavior: "smooth", block: "center" });
-                        span.remove();
-                    }
+                function isSafari() {
+                    return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+                }
+                if (isSafari()) {
+                    scrollToCaret(range, "gametext", sel);
+                } else {
+                    const span = document.createElement("span");
+                    span.style.display = "inline";
+                    span.style.background = "transparent";
+                    span.id = "temp-scroll-target";
+                    const tempRange = range.cloneRange();
+                    tempRange.collapse(true);
+                    tempRange.insertNode(span);
+                    span.scrollIntoView({ behavior: "smooth", block: "center" });
+                    setTimeout(() => {
+                        if (span.parentNode) span.parentNode.removeChild(span);
+                    }, 500);
                 }
             };
             resultsContainer.appendChild(btn);


### PR DESCRIPTION
Hi @LostRuins, I checked your refactor and I have here some feedbacks with some changes I would like to propose.

Bad code practices:

- Assigning potentially arbitrary strings to `.innerHtml` is BAD, please avoid it at least on new code (see <https://www.geeksforgeeks.org/javascript/what-is-the-disadvantage-of-using-innerhtml-in-javascript/> and <https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#replacing_the_contents_of_an_element>).
- Using "==" for comparison (like in <https://github.com/LostRuins/lite.koboldai.net/blob/ab22e039f7943ec3902c040fdd05caa4ed5e2bed/index.html#L13266>) is BAD because it causes implicit type coercion, please avoid it at least on new code.

A good practice would be also start adding E2E tests with frameworks like playwright.

Bugs:

- You use type="text" for the input element id="wordsearch_input": this on android devices (not sure on android tablets - I don't have one - but for sure on android phones with google chrome) will remove the "Enter" button from keyboard user phones (see <https://stackoverflow.com/questions/72369349/google-chrome-101-on-android-shows-tab-key-on-so.ft-keyboard-instead-of-enter-for>, I ended using type="search" on the my input search element).
- Switching from read-only to edit mode (and reverse) will break the word indexes. To avoid this you should modify btn_editmode() to re-run also the word search function to recalculate again the word indexes each time users toggle the edit mode.

Functional bad decisions:

- Hardcoded ngram number? Why? You could simply add a number input field setting (I added min=1, max=9, value=2 in my implementation, see <https://github.com/trincadev/lite.koboldai.net/blob/369f7f2a74c15df85faac9b8a5b7ec66899478f8/index.html#L25275>)
- the full text search will match also substrings and this will cause, in my opinion, two wrong behaviours:
  - it put togheter words with very different meaning like "the" and "they" (and remenber that one of the requests was to automatically ban duplicated words... we risk to ban the wrong words)
  - it match also substrings, e.g. the "a" letters (in your initial Harry Potter's txt example - I extracted the raw text for this check - there are 5299 'a' letters, but only 288 single 'a' words). This is also the reason, I think, for which there are some performance issues in your current refactoring with the Harry Potter's example json text.

I hope you will like my proposed changes. Right now I'm keeping the assigns to .innerHtml because I want your feedback for my changes before doing too much work.
Also the regex I'm using:

```
const WORD_REGEX = /[A-Za-zÀ-ÖØ-öø-ÿ0-9"'-’]+/g;
```

It's probably incomplete but I think you have something like this already in the project, I'm right? I'm also trying to see if it's better to do the contrary, matching instead the punctuation signs and splitting/stemming this way.

However, I'm still working on preparing up-to-dated playwright tests to

- finish the refactor:
  - safely remove the assigns to `.innerHtml`
  - decrease the cognitive complexity of `trigger_wordsearch_results()` and `trigger_wordsearch_candidates()`
- after clicking on the results of `trigger_wordsearch_results()`, I want to emphasize ONLY the selected row (I did it in my old implementation)
