### PR TITLE
Make indentation more consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -1455,7 +1455,7 @@ Current version indicated by LITEVER below.
 		padding-left: 10px;
 		padding-right: 10px;
 		padding-top: 7px;
-        border: 1px solid #bbbbbbaa;
+		border: 1px solid #bbbbbbaa;
 	}
 	.cht_inp_bg_inner
 	{
@@ -1490,7 +1490,7 @@ Current version indicated by LITEVER below.
 		width: 33px;
 		background-size: 50% !important;
 		background-repeat: no-repeat !important;
- 		background-position: center !important;
+		background-position: center !important;
 		background-image: var(--img_chat) !important;
 	}
 	.chat_btnmode_adventure{
@@ -1507,7 +1507,7 @@ Current version indicated by LITEVER below.
 		width: 33px;
 		background-size: 50% !important;
 		background-repeat: no-repeat !important;
- 		background-position: center !important;
+		background-position: center !important;
 	}
 	.chat_btnmode_adventure.storymode
 	{
@@ -1535,7 +1535,7 @@ Current version indicated by LITEVER below.
 		width: 33px;
 		background-size: 50% !important;
 		background-repeat: no-repeat !important;
- 		background-position: center !important;
+		background-position: center !important;
 		background-image: var(--img_chat_send_btn) !important;
 	}
 	.chat_msg_send_btn:hover {
@@ -1567,7 +1567,7 @@ Current version indicated by LITEVER below.
 		width: 33px;
 		background-size: 50% !important;
 		background-repeat: no-repeat !important;
- 		background-position: center !important;
+		background-position: center !important;
 		background-image: var(--img_chat_abort_btn) !important;
 	}
 	.chat_msg_send_btn_abort:hover {
@@ -1590,7 +1590,7 @@ Current version indicated by LITEVER below.
 		width: 33px;
 		background-size: 64% !important;
 		background-repeat: no-repeat !important;
-  		background-position: center !important;
+		background-position: center !important;
 		background-image: var(--img_chat_cust_btn) !important ;
 
 	}
@@ -1725,7 +1725,7 @@ Current version indicated by LITEVER below.
 		padding-right: 12px;
 		padding-top: 8px;
 		width:100%;
-        border: 1px solid #bbbbbbaa;
+		border: 1px solid #bbbbbbaa;
 		position: relative;
 	}
 	.corpo_edit_inner
@@ -1754,7 +1754,7 @@ Current version indicated by LITEVER below.
 		padding-left: 52px;
 		padding-right: 52px;
 		padding-top: 8px;
-        border: 1px solid #bbbbbbaa;
+		border: 1px solid #bbbbbbaa;
 		position: relative;
 	}
 	body.darkmode .corpo_chat_outer
@@ -1793,7 +1793,7 @@ Current version indicated by LITEVER below.
 		width: 33px;
 		background-size: 50% !important;
 		background-repeat: no-repeat !important;
- 		background-position: center !important;
+		background-position: center !important;
 		background-image: var(--img_corpo_clip) !important;
 	}
 	.corpo_chat_img_btn:hover {
@@ -1816,7 +1816,7 @@ Current version indicated by LITEVER below.
 		width: 33px;
 		background-size: 50% !important;
 		background-repeat: no-repeat !important;
- 		background-position: center !important;
+		background-position: center !important;
 		background-image: var(--img_corpo_send_btn) !important;
 	}
 	.corpo_chat_send_btn:hover {
@@ -1839,7 +1839,7 @@ Current version indicated by LITEVER below.
 		width: 33px;
 		background-size: 50% !important;
 		background-repeat: no-repeat !important;
- 		background-position: center !important;
+		background-position: center !important;
 		background-image: var(--img_corpo_abort_btn) !important;
 	}
 	.corpo_btn_text
@@ -1859,7 +1859,7 @@ Current version indicated by LITEVER below.
 		width: 32px;
 		background-size: 60% !important;
 		background-repeat: no-repeat !important;
- 		background-position: center !important;
+		background-position: center !important;
 	}
 	.corpo_hover_btn:hover {
 		background: #eeeeee none repeat scroll 0 0;
@@ -1882,22 +1882,22 @@ Current version indicated by LITEVER below.
 		background-color: #161616;
 	}
 	.corpoendeditbutton {
-      position: fixed;
-      top: 75px;
-      right: 25px;
-	  width: 40px;
-      padding: 8px 6px;
-      background-color: #de5b5b;
-      color: white;
-      border-radius: 24px;
-	  opacity: 0.65;
-      cursor: pointer;
-      box-shadow: 1 2px 8px rgba(0, 0, 0, 0.2);
-    }
+		position: fixed;
+		top: 75px;
+		right: 25px;
+		width: 40px;
+		padding: 8px 6px;
+		background-color: #de5b5b;
+		color: white;
+		border-radius: 24px;
+		opacity: 0.65;
+		cursor: pointer;
+		box-shadow: 1 2px 8px rgba(0, 0, 0, 0.2);
+	}
 
-    .corpoendeditbutton:hover {
-      background-color: #f67676;
-    }
+	.corpoendeditbutton:hover {
+		background-color: #f67676;
+	}
 	.corpoleftpanelitems
 	{
 		display: flex;
@@ -1936,10 +1936,10 @@ Current version indicated by LITEVER below.
 		cursor: pointer;
 		font-size: 17px;
 		background-repeat: no-repeat;
-    	background-position: 8px;
+		background-position: 8px;
 		background-size: 24px;
 		overflow: hidden;
-    	text-overflow: ellipsis;
+		text-overflow: ellipsis;
 		white-space: nowrap;
 		user-select: none;
 		width: 100%;
@@ -1947,14 +1947,14 @@ Current version indicated by LITEVER below.
 	.corpo_leftpanel_btn:hover {
 		background: #9dcef5;
 		background-repeat: no-repeat;
-    	background-position: 8px;
+		background-position: 8px;
 		background-size: 24px;
 	}
 	.corpo_leftpanel_btn.red:hover {
 		color: #000000;
 		background: #f5767f;
 		background-repeat: no-repeat;
-    	background-position: 8px;
+		background-position: 8px;
 		background-size: 24px;
 	}
 	.corpo_leftpanel_btn:active {
@@ -1965,7 +1965,7 @@ Current version indicated by LITEVER below.
 		color: #76a8ee;
 		background: #454545;
 		background-repeat: no-repeat;
-    	background-position: 8px;
+		background-position: 8px;
 		background-size: 24px;
 	}
 	body.darkmode .corpo_leftpanel_btn.red:hover
@@ -1973,7 +1973,7 @@ Current version indicated by LITEVER below.
 		color: #000000;
 		background: #f5767f;
 		background-repeat: no-repeat;
-    	background-position: 8px;
+		background-position: 8px;
 		background-size: 24px;
 	}
 	.corporightpanel
@@ -1981,7 +1981,7 @@ Current version indicated by LITEVER below.
 		width: 100%;
 		height: calc(100vh - 68px);
 		display: flex;
-    	flex-direction: column;
+		flex-direction: column;
 		padding-left: 2px;
 		padding-right: 2px;
 	}
@@ -2076,7 +2076,7 @@ Current version indicated by LITEVER below.
 	{
 		max-width: 860px;
 		margin-left: auto;
-    	margin-right: auto;
+		margin-right: auto;
 		padding-left: 8px;
 		padding-right: 8px;
 	}
@@ -3051,8 +3051,8 @@ Current version indicated by LITEVER below.
 	const default_cohere_base = "https://api.cohere.ai/v1/chat";
 
 	const a1111_models_endpoint = "/sdapi/v1/sd-models";
-    const a1111_options_endpoint = "/sdapi/v1/options";
-    const a1111_txt2img_endpoint = "/sdapi/v1/txt2img";
+	const a1111_options_endpoint = "/sdapi/v1/options";
+	const a1111_txt2img_endpoint = "/sdapi/v1/txt2img";
 	const a1111_img2img_endpoint = "/sdapi/v1/img2img";
 	const a1111_interrogate_endpoint = "/sdapi/v1/interrogate";
 
@@ -4709,12 +4709,12 @@ Current version indicated by LITEVER below.
 		}
 
 		const request = indexedDB.open(STORAGE_PREFIX, 1);
-        request.onsuccess = (event) => {
+		request.onsuccess = (event) => {
 			const db = event.target.result;
 			const transaction = db.transaction(STORAGE_PREFIX, "readonly");
 			const store = transaction.objectStore(STORAGE_PREFIX);
-            const getRequest = store.get(objkey);
-            getRequest.onsuccess = () => {
+			const getRequest = store.get(objkey);
+			getRequest.onsuccess = () => {
 				let res = getRequest.result;
 				if(res){
 					resolve(res.value); //since it was json previously, return it
@@ -4722,12 +4722,12 @@ Current version indicated by LITEVER below.
 					resolve(defaultvalue);
 				}
 			}
-            getRequest.onerror = () =>
+			getRequest.onerror = () =>
 			{
 				console.log(getRequest.error);
 				fallbackResolveLoad();
 			}
-        };
+		};
 
 		request.onupgradeneeded = function(event)
 		{
@@ -4743,12 +4743,12 @@ Current version indicated by LITEVER below.
 			}
 		}
 
-      	request.onerror = function(event)
+		request.onerror = function(event)
 		{
 			console.error(`Unable to initialize IndexedDB Database! Fallback to localstorage.`);
 			fallbackResolveLoad();
 		}
-    	});
+		});
 	}
 	function readTavernPngFromBlob(blob, onDone) // File loading and import functionality
 	{
@@ -4981,7 +4981,7 @@ Current version indicated by LITEVER below.
 				}
 				var plainfile = unzip.decompress(correctfile);
 				const decoder = new TextDecoder('utf-8');
-            	const readtxt = decoder.decode(plainfile);
+				const readtxt = decoder.decode(plainfile);
 				var decoded = JSON.parse(readtxt);
 				console.log(decoded);
 				return decoded;
@@ -4991,7 +4991,7 @@ Current version indicated by LITEVER below.
 			}
 		}
 		return null;
-    };
+	};
 
 	function extractRisuData(arr) {
 		function strToBytes(str) {
@@ -5780,7 +5780,7 @@ Current version indicated by LITEVER below.
 	}
 
 	function playbeep() {
-    	var sound = new Audio("data:audio/wav;base64,UklGRkwBAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YScBAAB8gIN8fICAgIB8gHmAjXVkhptyXYqbcmiKjXKAim5ymIpWcqmKU3Klhl18kXl5jXlkjZ5oVpelZFaUm2trioN1ioZkeaKDU3msgFN8nnxog4Nyg5FrZJubXWGem2FnlIpufIZyfJR8XYOleVaDonlhg5F1eYZ5dZGNYXWbimhrm4Nrg3KDjWt/hm6UkUmDvV1TrINdkXxol4Boinx1nmtWr5RChqVheZdkeZtucop1io1WgLNhWql/XZd/YZSNZH+GeY1yZKKNUIaeZHmYZ3WbeWuGg4B/a4Oba2uXgGuNf2iKjWt5ioB/eXWNg2t/jXJ8inJ5kXxug4N8fHl/hnl1hnx5hn91g4Z1fIN8fHx8f4B5gIB8gH98fIN8fH+AfHx8fH98fIB/AA==");
+		var sound = new Audio("data:audio/wav;base64,UklGRkwBAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YScBAAB8gIN8fICAgIB8gHmAjXVkhptyXYqbcmiKjXKAim5ymIpWcqmKU3Klhl18kXl5jXlkjZ5oVpelZFaUm2trioN1ioZkeaKDU3msgFN8nnxog4Nyg5FrZJubXWGem2FnlIpufIZyfJR8XYOleVaDonlhg5F1eYZ5dZGNYXWbimhrm4Nrg3KDjWt/hm6UkUmDvV1TrINdkXxol4Boinx1nmtWr5RChqVheZdkeZtucop1io1WgLNhWql/XZd/YZSNZH+GeY1yZKKNUIaeZHmYZ3WbeWuGg4B/a4Oba2uXgGuNf2iKjWt5ioB/eXWNg2t/jXJ8inJ5kXxug4N8fHl/hnl1hnx5hn91g4Z1fIN8fHx8f4B5gIB8gH98fIN8fH+AfHx8fH98fIB/AA==");
 		sound.play();
 		console.log("beep sound");
 	}
@@ -5863,7 +5863,7 @@ Current version indicated by LITEVER below.
 			if (innercode.startsWith(matcher)) {
 				innercode = innercode.substring(matcher.length);
 				break;
-			 }
+			}
 		}
 		copyToClipboard(innercode);
 	}
@@ -6330,7 +6330,7 @@ Current version indicated by LITEVER below.
 
 
 	function connect_to_a1111(silent=false)
-    {
+	{
 		console.log("Attempt A1111 Connection...");
 		//establish initial connection to a1111 api
 		fetch(localsettings.saved_a1111_url + a1111_models_endpoint)
@@ -6390,7 +6390,7 @@ Current version indicated by LITEVER below.
 
 
 	function connect_to_comfyui(silent=false)
-    {
+	{
 		console.log("Attempt ComfyUI Connection...");
 		//establish initial connection to a1111 api
 		fetch(localsettings.saved_comfy_url + comfy_models_endpoint)
@@ -8515,7 +8515,7 @@ Current version indicated by LITEVER below.
 	{
 		hide_popups();
 		document.getElementById("charcreator_name").value = document.getElementById("charcreator_persona").value = document.getElementById("charcreator_scenario").value = document.getElementById("charcreator_greeting").value = "";
-        document.getElementById("usecharactertemplate").checked = false;
+		document.getElementById("usecharactertemplate").checked = false;
 		document.getElementById("charactercreator").classList.remove("hidden");
 		tempAestheticInstructUISettings = deepCopyAestheticSettings(aestheticInstructUISettings);
 		character_creator_updateimg();
@@ -8598,9 +8598,9 @@ Current version indicated by LITEVER below.
 		tempAestheticInstructUISettings = null;
 		hide_popups();
 		if (confirm && usingtemplate)
-        {
-            btn_memory();
-        }
+		{
+			btn_memory();
+		}
 	}
 
 	function click_scenario(idx)
@@ -9081,7 +9081,7 @@ Current version indicated by LITEVER below.
 					}
 					return userInput;
 				}
-				 else {
+				else {
 					userInput = userInput.split("#")[0].split("?")[0];
 					userInput = userInput.endsWith('/') ? userInput.slice(0, -1) : userInput;
 					if (userInput.match(/aicharactercards\.com\//i) || userInput.match(/AICC\//i)) {
@@ -9304,14 +9304,14 @@ Current version indicated by LITEVER below.
 		let searchstr = document.getElementById("scenariosearch").value.trim().toLowerCase();
 		let sdrop = document.getElementById("scenariosearchdropdown").value;
 		let sgrid_nodes = sgrid.children;
-        for(let i=0; i<sgrid_nodes.length; i++){
-            let schild = sgrid_nodes[i];
+		for(let i=0; i<sgrid_nodes.length; i++){
+			let schild = sgrid_nodes[i];
 			let elem = null;
 			if(schild.name!="")
 			{
 				elem = scenario_db[schild.name];
 			}
-            if(searchstr=="" || schild.innerText.trim().toLowerCase().includes(searchstr))
+			if(searchstr=="" || schild.innerText.trim().toLowerCase().includes(searchstr))
 			{
 				if(sdrop==0 || (elem && sdrop==elem.opmode))
 				{
@@ -9324,7 +9324,7 @@ Current version indicated by LITEVER below.
 			}else{
 				schild.style.display = "none";
 			}
-        }
+		}
 	}
 
 	function show_last_req()
@@ -12124,15 +12124,15 @@ Current version indicated by LITEVER below.
 		let pickedparent = document.getElementById("pickedmodel");
 		let pickedentries = pickedparent.children;
 		let searchstr = document.getElementById("modelquicksearch").value.trim().toLowerCase();
-        for(let i=0; i<pickedentries.length; i++){
-            let schild = pickedentries[i];
-            if(searchstr=="" || schild.text.trim().toLowerCase().includes(searchstr))
+		for(let i=0; i<pickedentries.length; i++){
+			let schild = pickedentries[i];
+			if(searchstr=="" || schild.text.trim().toLowerCase().includes(searchstr))
 			{
 				schild.style.display = "block";
 			}else{
 				schild.style.display = "none";
 			}
-        }
+		}
 	}
 
 	function confirm_horde_models() {
@@ -16298,7 +16298,7 @@ Current version indicated by LITEVER below.
 			const sentenceEndings = /[.!?]/g;
 			let lastsentences = gametext_arr[gametext_arr.length-1].split(sentenceEndings);
 			lastsentences = lastsentences.map(lastsentences => lastsentences.trim()); //remove whitespace
-    		lastsentences = lastsentences.filter(lastsentences => lastsentences.length > 0);
+			lastsentences = lastsentences.filter(lastsentences => lastsentences.length > 0);
 			if(lastsentences.length>0)
 			{
 				let lastsentence = lastsentences[lastsentences.length - 1];
@@ -21340,7 +21340,7 @@ Current version indicated by LITEVER below.
 				pending_wi_obj[idx - 1] = pending_wi_obj[idx];
 				pending_wi_obj[idx] = temp;
 			}
-   		}
+		}
 		update_wi();
 	}
 
@@ -21356,7 +21356,7 @@ Current version indicated by LITEVER below.
 				pending_wi_obj[idx + 1] = pending_wi_obj[idx];
 				pending_wi_obj[idx] = temp;
 			}
-   		}
+		}
 		update_wi();
 	}
 
@@ -21949,8 +21949,8 @@ Current version indicated by LITEVER below.
 	}
 	const stableSort = (arr, compare) => {
 	return arr.map((item, index) => ({ item, index }))
-     .sort((a, b) => compare(a.item, b.item) || a.index - b.index)
-     .map(({ item }) => item);
+		.sort((a, b) => compare(a.item, b.item) || a.index - b.index)
+		.map(({ item }) => item);
 	};
 	</script>
 
@@ -22880,30 +22880,30 @@ Current version indicated by LITEVER below.
 		recentTextStr = replace_search_placeholders(recentTextStr);
 
 		let i = 0;
-        allText.split("[DOCUMENT BREAK]").forEach(doc => {
-            doc = doc.trim();
-            if (!doc) { return; }
-            let titleMatch = doc.match(/^\[([^\n]+?)\]/);
-            let title = null;
-            if (titleMatch !== null)
-            {
-                doc = doc.replace(titleMatch[0], "");
-                title = titleMatch[1];
-            }
-            let startLoc = 0;
-            while (startLoc < doc.length && i < Number.MAX_SAFE_INTEGER) {
-                let actualChunkStart = Math.max(0, startLoc - chunkSizeOverlap);
-                let actualChunkEnd = Math.min(doc.length, actualChunkStart + chunkSize);
-                let currentSnippet = doc.substring(actualChunkStart, actualChunkEnd);
-                paragraphs.push({snippet: currentSnippet, document: title});
-                startLoc = actualChunkEnd;
-                i++;
-            }
-        });
-        paragraphs = paragraphs.map(c => {
-            c.snippet = c.snippet.replace(/\n\n/g, "\n");
-            return c;
-        }).filter(c => !!c.snippet);
+		allText.split("[DOCUMENT BREAK]").forEach(doc => {
+			doc = doc.trim();
+			if (!doc) { return; }
+			let titleMatch = doc.match(/^\[([^\n]+?)\]/);
+			let title = null;
+			if (titleMatch !== null)
+			{
+				doc = doc.replace(titleMatch[0], "");
+				title = titleMatch[1];
+			}
+			let startLoc = 0;
+			while (startLoc < doc.length && i < Number.MAX_SAFE_INTEGER) {
+				let actualChunkStart = Math.max(0, startLoc - chunkSizeOverlap);
+				let actualChunkEnd = Math.min(doc.length, actualChunkStart + chunkSize);
+				let currentSnippet = doc.substring(actualChunkStart, actualChunkEnd);
+				paragraphs.push({snippet: currentSnippet, document: title});
+				startLoc = actualChunkEnd;
+				i++;
+			}
+		});
+		paragraphs = paragraphs.map(c => {
+			c.snippet = c.snippet.replace(/\n\n/g, "\n");
+			return c;
+		}).filter(c => !!c.snippet);
 
 		let miniSearch;
 		if ((documentdb_provider==2 && is_using_kcpp_with_embeddings()) || documentdb_provider==3)
@@ -23096,7 +23096,7 @@ Current version indicated by LITEVER below.
 	{
 		if (event.key === 'Enter') {
 			trigger_wordsearch_candidates();
-        }
+		}
 	}
 
 	function trigger_wordsearch_results(query) {
@@ -23437,7 +23437,7 @@ Current version indicated by LITEVER below.
 				<li id="memory_tab" class="active"><a class="" href="#" onclick="display_memory_tab(0)">Memory</a></li>
 				<li id="wi_tab"><a class="" href="#" onclick="display_memory_tab(1)">World Info</a></li>
 				<li id="documentdb_tab"><a class="" href="#" onclick="display_memory_tab(2)">TextDB</a></li>
-			  </ul></div>
+			</ul></div>
 
 			<div class="context_tab_container" id="memory_tab_container">
 				<div class="settinglabel">
@@ -23682,7 +23682,7 @@ Current version indicated by LITEVER below.
 							<button type="button" class="btn btn-primary" id="btn_aesthetics" onclick="openAestheticUISettingsMenu()" style="border-color: #bbbbbb; width:100%; height:30px; padding:0px 8px; margin: 3px 0 3px 0;">⚙️ Customize</button>
 							<div id="classicmodeoptions" style="margin:4px;" class="settinglabel hidden">
 							<div class="justifyleft settingsmall">Word Frequency Analysis <span class="helpicon">?<span class="helptext">Shows a tool that displays word frequency and locations, inspired by trincadev MyGhostWriter. Counts across newlines may be inaccurate.</span></span></div>
-							   <input title="WordSearch Tool" type="checkbox" id="wordsearch_toggle" style="margin:0px 0px 0px 0px;">
+								<input title="WordSearch Tool" type="checkbox" id="wordsearch_toggle" style="margin:0px 0px 0px 0px;">
 							</div>
 							<div id="guitypedesc" class="settingsdesctxt"></div>
 						</div>
@@ -23862,17 +23862,17 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Context Size <span class="helpicon">?<span class="helptext">Maximum number of context tokens submitted to the AI. Must exceed max output tokens. Can be further increased by editing the textbox. Older models stop at 2048, newer ones can do 4096 or greater.</span></span></div>
 							<input title="Context Size" inputmode="numeric" class="justifyright flex-push-right settingsmall widerinput" id="max_context_length" oninput="
-						   document.getElementById('max_context_length_slide').value = this.value;">
+							document.getElementById('max_context_length_slide').value = this.value;">
 						</div>
 						<div><input title="Context Size Slider" type="range" min="512" max="4096" step="8" id="max_context_length_slide" oninput="
-						   document.getElementById('max_context_length').value = this.value;"></div>
+							document.getElementById('max_context_length').value = this.value;"></div>
 						<div class="settingminmax">
 							<div class="justifyleft">512</div>
 							<div class="justifyright" id="max_context_length_slide_label">4096</div>
 						</div>
 						<div id="auto_ctxlen_panel" class="settinglabel">
 							<div class="justifyleft settingsmall" title="Automatically lowers settings if incompatible with existing workers">Auto-Adjust Limits </div>
-						   <input title="Auto-Adjust Context Limits" type="checkbox" id="auto_ctxlen" style="margin:0px 0 0;">
+							<input title="Auto-Adjust Context Limits" type="checkbox" id="auto_ctxlen" style="margin:0px 0 0;">
 						</div>
 					</div>
 
@@ -23881,17 +23881,17 @@ Current version indicated by LITEVER below.
 							<div class="justifyleft settingsmall">Max Output <span class="helpicon">?<span
 										class="helptext">Number of tokens the AI should generate. Higher numbers will take longer to generate.</span></span></div>
 							<input title="Max Output" inputmode="numeric" class="justifyright flex-push-right settingsmall" id="max_length" oninput="
-						   document.getElementById('max_length_slide').value = this.value;">
+							document.getElementById('max_length_slide').value = this.value;">
 						</div>
 						<div><input title="Max Output Slider" type="range" min="16" max="512" step="2"	id="max_length_slide" oninput="
-						   document.getElementById('max_length').value = this.value;"></div>
+							document.getElementById('max_length').value = this.value;"></div>
 						<div class="settingminmax">
 							<div class="justifyleft">16</div>
 							<div class="justifyright" id="max_length_slide_label">512</div>
 						</div>
 						<div id="auto_genamt_panel" class="settinglabel">
 							<div class="justifyleft settingsmall" title="Automatically lowers settings if incompatible with existing workers">Auto-Adjust Limits </div>
-						   <input title="Auto-Adjust Length Limits" type="checkbox" id="auto_genamt" style="margin:0px 0 0;">
+							<input title="Auto-Adjust Length Limits" type="checkbox" id="auto_genamt" style="margin:0px 0 0;">
 						</div>
 					</div>
 
@@ -23906,7 +23906,7 @@ Current version indicated by LITEVER below.
 						</div>
 						<div><input title="Temperature Slider" type="range" min="0.1" max="2" step="0.01"
 								id="temperature_slide" oninput="
-						   document.getElementById('temperature').value = this.value;"></div>
+							document.getElementById('temperature').value = this.value;"></div>
 						<div class="settingminmax">
 							<div class="justifyleft">0.1</div>
 							<div class="justifyright">2</div>
@@ -23919,7 +23919,7 @@ Current version indicated by LITEVER below.
 										class="helptext">Used to penalize words that were already generated or belong to
 										the context (too high causes incoherence!).</span></span></div>
 							<input title="Repetition Penalty" inputmode="decimal" class="justifyright flex-push-right settingsmall" id="rep_pen" oninput="
-						   document.getElementById('rep_pen_slide').value = this.value;">
+							document.getElementById('rep_pen_slide').value = this.value;">
 						</div>
 						<div><input title="Repetition Penalty Slider" type="range" min="1" max="2" step="0.01"
 								id="rep_pen_slide" oninput="document.getElementById('rep_pen').value = this.value;"></div>
@@ -23935,7 +23935,7 @@ Current version indicated by LITEVER below.
 										to discard unlikely text in a nucleus sampling process. Lower values will make text
 										more predictable but can become repetitious. Set to 1 to deactivate it.</span></span></div>
 							<input title="Top-P Sampling" inputmode="decimal" class="justifyright flex-push-right settingsmall" id="top_p" oninput="
-						   document.getElementById('top_p_slide').value = this.value;">
+							document.getElementById('top_p_slide').value = this.value;">
 						</div>
 						<div><input title="Top-P Sampling Slider" type="range" min="0" max="1" step="0.01" id="top_p_slide"
 								oninput="document.getElementById('top_p').value = this.value;"></div>
@@ -23949,7 +23949,7 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Top-K Sampling <span class="helpicon">?<span class="helptext">Top-K Sampling. Discards all but the K most likely tokens. Set 0 to Deactivate. Range 0 to 100.</span></span></div>
 							<input title="Top-K Sampling"inputmode="decimal" class="justifyright flex-push-right settingsmall" id="top_k" oninput="
-						   document.getElementById('top_k_slide').value = this.value;">
+							document.getElementById('top_k_slide').value = this.value;">
 						</div>
 						<div><input title="Top-K Sampling Slider" type="range" min="0" max="100" step="1" id="top_k_slide"
 								oninput="document.getElementById('top_k').value = this.value;"></div>
@@ -24187,7 +24187,7 @@ Current version indicated by LITEVER below.
 								</div>
 							<div class="settinglabel">
 								<div class="justifyleft settingsmall"  title="Save images remotely on A1111/Forge host (caution)">Save In A1111/Forge </div>
-							   <input type="checkbox" id="save_remote_images" style="margin:0px 0px 0px auto;">
+								<input type="checkbox" id="save_remote_images" style="margin:0px 0px 0px auto;">
 							</div>
 							</div>
 							<div id="generate_images_comfy_container" class="settinglabel hidden">
@@ -24226,7 +24226,7 @@ Current version indicated by LITEVER below.
 								</div>
 								<div class="settinglabel">
 									<div class="justifyleft settingsmall"  title="Includes images when saving to json file">Save Images </div>
-								   <input title="Save Images in File" type="checkbox" id="save_images" style="margin:0px 0px 0px auto;">
+									<input title="Save Images in File" type="checkbox" id="save_images" style="margin:0px 0px 0px auto;">
 								</div>
 							</div>
 
@@ -24329,11 +24329,11 @@ Current version indicated by LITEVER below.
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall"  title="If unchecked, only speak AI replies, not other text.">Narrate Both Sides </div>
-						   <input title="Narrate Both Sides" type="checkbox" id="narrate_both_sides" style="margin:0px 0px 0px auto;">
+							<input title="Narrate Both Sides" type="checkbox" id="narrate_both_sides" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall"  title="If unchecked, only speak AI replies, not other text.">Narrate Only Dialog </div>
-						   <input title="Narrate Only Dialog" type="checkbox" id="narrate_only_dialog" style="margin:0px 0px 0px auto;">
+							<input title="Narrate Only Dialog" type="checkbox" id="narrate_only_dialog" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="inlinelabel" style="font-size: 11px;">
 							<div class="justifyleft">Browser TTS Speed: </div>
@@ -24351,7 +24351,7 @@ Current version indicated by LITEVER below.
 						</div>
 						<div class="inlinelabel" style="font-size: 11px;">
 							<div class="justifyleft" style="padding:2px"  title="Suppress non-speech (e.g. music and sounds) from transcription">Suppress Non-Speech </div>
-						  	<input title="Suppress Non-Speech" type="checkbox" id="voice_suppress_nonspeech" style="margin:0px 0px 0px auto;">
+							<input title="Suppress Non-Speech" type="checkbox" id="voice_suppress_nonspeech" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="inlinelabel" style="font-size: 11px;">
 							<div class="justifyleft" style="padding:2px"  title="Language Code">Language </div>
@@ -24593,7 +24593,7 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall" id="tokenstreaminglabel">Token Streaming <span class="helpicon">?<span
 								class="helptext">Use token streaming for partial responses. SSE is smoother but less well-supported. Poll is chunkier but more reliable. Not available on Horde.</span></span></div>
-						   <select title="Token Streaming" style="padding:1px; height:auto; width: 34px; appearance: none; font-size: 7pt; margin:0px 0px 0px auto;" class="form-control" id="tokenstreammode">
+							<select title="Token Streaming" style="padding:1px; height:auto; width: 34px; appearance: none; font-size: 7pt; margin:0px 0px 0px auto;" class="form-control" id="tokenstreammode">
 								<option value="0">Off</option>
 								<option value="1">Poll</option>
 								<option value="2">SSE</option>
@@ -24628,23 +24628,23 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Render Streaming Markdown <span class="helpicon">?<span
 								class="helptext">Attempt to render markdown when streaming. May result in wonky output or lag on older devices.</span></span></div>
-						   <input title="Show Local Endpoint Selector" type="checkbox" id="render_streaming_markdown" style="margin:0px 0px 0px auto;">
+							<input title="Show Local Endpoint Selector" type="checkbox" id="render_streaming_markdown" style="margin:0px 0px 0px auto;">
 						</div>
 
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Never Escape HTML <span class="helpicon">?<span
 								class="helptext">Avoids escaping any HTML tags, allowing HTML injections. Not recommended!</span></span></div>
-						   <input title="Never Escape HTML" type="checkbox" id="no_escape_html" style="margin:0px 0px 0px auto;">
+							<input title="Never Escape HTML" type="checkbox" id="no_escape_html" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Render Sp.Tags <span class="helpicon">?<span
 								class="helptext">If enabled, renders special tags like EOS and padding tokens. Not recommended.</span></span></div>
-						   <input title="Render Special Tags" type="checkbox" id="render_special_tags" style="margin:0px 0px 0px auto;">
+							<input title="Render Special Tags" type="checkbox" id="render_special_tags" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Request Logprobs <span class="helpicon">?<span
 								class="helptext">If enabled, request top 5 alternative token log-probabilities for each generated token. Incurs an overhead.</span></span></div>
-						   <input title="Request Logprobs" type="checkbox" id="request_logprobs" style="margin:0px 0px 0px auto;">
+							<input title="Request Logprobs" type="checkbox" id="request_logprobs" style="margin:0px 0px 0px auto;">
 						</div>
 					</div>
 
@@ -24658,22 +24658,22 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Embed Settings File <span class="helpicon">?<span
 								class="helptext">Includes your current settings when saving or sharing your story</span></span></div>
-						   <input title="Embed Settings File" type="checkbox" id="export_settings" style="margin:0px 0px 0px auto;">
+							<input title="Embed Settings File" type="checkbox" id="export_settings" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Rename Save File <span class="helpicon">?<span
 								class="helptext">Prompts to input a different filename when saving file.</span></span></div>
-						   <input title="Rename Save File" type="checkbox" id="prompt_for_savename" style="margin:0px 0px 0px auto;">
+							<input title="Rename Save File" type="checkbox" id="prompt_for_savename" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Show Advanced Load <span class="helpicon">?<span
 								class="helptext">If enabled, allows you to select additional configurations during file load</span></span></div>
-						   <input title="Show Advanced Load" type="checkbox" id="show_advanced_load" style="margin:0px 0px 0px auto;">
+							<input title="Show Advanced Load" type="checkbox" id="show_advanced_load" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Card Import Prompt <span class="helpicon">?<span
 								class="helptext">If enabled, prompts the user to choose what mode to import a character card in. If disabled, automatically picks chat mode.</span></span></div>
-						   <input title="Character Card Import Prompt" type="checkbox" id="import_tavern_prompt" style="margin:0px 0px 0px auto;">
+							<input title="Character Card Import Prompt" type="checkbox" id="import_tavern_prompt" style="margin:0px 0px 0px auto;">
 						</div>
 					</div>
 
@@ -24681,7 +24681,7 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Run In Background <span class="helpicon">?<span
 								class="helptext">Prevents the browser from suspending KoboldAI Lite by playing a silent audio track. This setting cannot be saved.</span></span></div>
-						   <input title="Run In Background" type="checkbox" id="run_in_background" style="margin:0px 0px 0px auto;">
+							<input title="Run In Background" type="checkbox" id="run_in_background" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">User Mods <span class="helpicon">?<span class="helptext">Allows you to load third-party user created mods (caution).</span></span></div>
@@ -24697,17 +24697,17 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Autoscroll Text <span class="helpicon">?<span
 								class="helptext">Automatically scrolls the text window down when new text is generated</span></span></div>
-						   <input title="Autoscroll Text" type="checkbox" id="autoscroll" style="margin:0px 0px 0px auto;">
+							<input title="Autoscroll Text" type="checkbox" id="autoscroll" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Unlock Scroll Height <span class="helpicon">?<span
 								class="helptext">Unlocks the text viewport, allowing for infinite height without scrolling</span></span></div>
-						   <input title="Unlock Scroll Height" type="checkbox" id="printer_view" style="margin:0px 0px 0px auto;">
+							<input title="Unlock Scroll Height" type="checkbox" id="printer_view" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Viewport Width <span class="helpicon">?<span
 								class="helptext">Controls horizontal scaling of the viewport window</span></span></div>
-						   <select title="Viewport Width" style="padding:1px; height:auto; width: 34px; appearance: none; font-size: 7pt; margin:0px 0px 0px auto;" class="form-control" id="viewport_width_mode">
+							<select title="Viewport Width" style="padding:1px; height:auto; width: 34px; appearance: none; font-size: 7pt; margin:0px 0px 0px auto;" class="form-control" id="viewport_width_mode">
 								<option value="0">Adapt</option>
 								<option value="1">Clamp</option>
 								<option value="2">HDClamp</option>
@@ -24717,12 +24717,12 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">SidePanel Mode <span class="helpicon">?<span
 								class="helptext">Displays the settings and context panels permanently on the sides, instead of as popups. Not available on Mobile displays.</span></span></div>
-						   <input title="Inverted Colors" type="checkbox" id="sidepanel_mode" style="margin:0px 0px 0px auto;">
+							<input title="Inverted Colors" type="checkbox" id="sidepanel_mode" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">Inverted Colors <span class="helpicon">?<span
 								class="helptext">Inverts all colors, simple light mode</span></span></div>
-						   <input title="Inverted Colors" type="checkbox" id="invert_colors" style="margin:0px 0px 0px auto;">
+							<input title="Inverted Colors" type="checkbox" id="invert_colors" style="margin:0px 0px 0px auto;">
 						</div>
 						<div class="settinglabel">
 							<input type="file" id="loadbgimg" accept="image/*" onchange="load_bg_img(event)" style="display:none;">
@@ -24736,12 +24736,12 @@ Current version indicated by LITEVER below.
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">RawInstructTags <span class="helpicon">?<span
 								class="helptext">Does not insert instruct placeholders, only uses raw tags</span></span></div>
-						   <input title="Raw Instruct Tags" type="checkbox" id="raw_instruct_tags" style="margin:0px 0px 0px 0px;">
+							<input title="Raw Instruct Tags" type="checkbox" id="raw_instruct_tags" style="margin:0px 0px 0px 0px;">
 						</div>
 						<div class="settinglabel">
 							<div class="justifyleft settingsmall">ShowEndpointSelector <span class="helpicon">?<span
 								class="helptext">Allows you to change the connected custom endpoint at runtime even in local mode.</span></span></div>
-						   <input title="Show Local Endpoint Selector" type="checkbox" id="show_endpoint_selector" style="margin:0px 0px 0px 0px;">
+							<input title="Show Local Endpoint Selector" type="checkbox" id="show_endpoint_selector" style="margin:0px 0px 0px 0px;">
 						</div>
 					</div>
 
@@ -25002,9 +25002,9 @@ Current version indicated by LITEVER below.
 					<div id="charcreator_avatar" style="background-position: 50% 50%; background-size: 100% 100%; background-origin: content-box; background-repeat: no-repeat; width: 32px; height:32px; border-radius:100rem; background-clip: content-box; margin: 4px 4px; border:none;"></div>
 				</div>
 				<div class="inlinelabel">
-                    <div class="justify-center" style="margin:4px;">Use Character Template <span class="helpicon">?<span class="helptext">Adds a character template to memory while creating the character instead.</span></span>
-                    <input type="checkbox" title="Use Character Template" id="usecharactertemplate" onchange="character_creator_template_toggle()" style="margin:0px 0px 0px auto;"></div>
-                </div>
+					<div class="justify-center" style="margin:4px;">Use Character Template <span class="helpicon">?<span class="helptext">Adds a character template to memory while creating the character instead.</span></span>
+					<input type="checkbox" title="Use Character Template" id="usecharactertemplate" onchange="character_creator_template_toggle()" style="margin:0px 0px 0px auto;"></div>
+				</div>
 				<div id="nocharactertemplate">
 				<div class="inlinelabel" style="padding-bottom: 4px;">
 					<div class="justifyleft" style="padding:4px">Character Persona: </div>


### PR DESCRIPTION
A very minor cleanup as I continue to poke at https://github.com/LostRuins/lite.koboldai.net/issues/94

`index.html` uses tabs for indentation, but some spaces have crept in here and there. I went through and turned them all into tabs, trying to match the existing indentation.

The reason this affects conversion is that I'd like to remove the base indentation when writing the individual files - but the indentation can't be detected if it's inconsistent. Unfortunately this does make things a bit fragile, but on the plus side consistent indentation is good, right?