### PR TITLE
feat: integrate dry_penalty_last_n setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -3811,6 +3811,7 @@ Current version indicated by LITEVER below.
 		dry_multiplier: 0.0,
 		dry_base: 1.75,
 		dry_allowed_length: 2,
+		dry_penalty_last_n: 320,
 		dry_sequence_breakers: ["\n", ":", "\"", "*"],
 		xtc_threshold: 0.2,
 		xtc_probability: 0.0,
@@ -13330,6 +13331,7 @@ Current version indicated by LITEVER below.
 		document.getElementById("xtc_probability").value = localsettings.xtc_probability;
 		document.getElementById("dry_base").value = localsettings.dry_base;
 		document.getElementById("dry_allowed_length").value = localsettings.dry_allowed_length;
+		document.getElementById("dry_penalty_last_n").value = localsettings.dry_penalty_last_n;
 		document.getElementById("token_count_multiplier").value = localsettings.token_count_multiplier;
 		document.getElementById("second_ep_qty").value = localsettings.second_ep_qty;
 		document.getElementById("second_ep_model").value = localsettings.second_ep_model;
@@ -13955,6 +13957,7 @@ Current version indicated by LITEVER below.
 		localsettings.dry_multiplier = parseFloat(document.getElementById("dry_multiplier").value);
 		localsettings.dry_base = parseFloat(document.getElementById("dry_base").value);
 		localsettings.dry_allowed_length = parseInt(document.getElementById("dry_allowed_length").value);
+		localsettings.dry_penalty_last_n = parseInt(document.getElementById("dry_penalty_last_n").value);
 		localsettings.dry_sequence_breakers = pendingsequencebreakers;
 		localsettings.custom_jailbreak_text = pendingassistantjailbreak;
 		localsettings.xtc_threshold = parseFloat(document.getElementById("xtc_threshold").value);
@@ -14163,6 +14166,7 @@ Current version indicated by LITEVER below.
 		localsettings.dry_multiplier = cleannum(localsettings.dry_multiplier, 0.0, 100.0);
 		localsettings.dry_base = cleannum(localsettings.dry_base, 0.0, 8.0);
 		localsettings.dry_allowed_length = cleannum(Math.floor(localsettings.dry_allowed_length), 0, 100);
+		localsettings.dry_penalty_last_n = cleannum(localsettings.dry_penalty_last_n, 0.0, localsettings.max_context_length);
 		localsettings.xtc_probability = cleannum(localsettings.xtc_probability, 0.0, 1.0);
 		localsettings.xtc_threshold = cleannum(localsettings.xtc_threshold, 0.0, 1.0);
 		localsettings.sampler_seed = cleannum(localsettings.sampler_seed, -1, 999999);
@@ -17634,7 +17638,7 @@ Current version indicated by LITEVER below.
 			submit_payload.params.dry_multiplier = localsettings.dry_multiplier;
 			submit_payload.params.dry_base = localsettings.dry_base;
 			submit_payload.params.dry_allowed_length = localsettings.dry_allowed_length;
-			submit_payload.params.dry_penalty_last_n = localsettings.rep_pen_range;
+			submit_payload.params.dry_penalty_last_n = localsettings.dry_penalty_last_n;
 			submit_payload.params.dry_sequence_breakers = JSON.parse(JSON.stringify(localsettings.dry_sequence_breakers));
 		}
 
@@ -25951,6 +25955,11 @@ Current version indicated by LITEVER below.
 										<div title="DRY Allowed Length" class="justifyleft settingsmall" style="width:100%">A.Len</div>
 										<div class="justifyleft settingsmall" style="width:100%">
 										<input title="DRY Allowed Length" class="settinglabel miniinput" type="text" inputmode="decimal" placeholder="0.0" value="0.0" id="dry_allowed_length"></div>
+									</div>
+									<div class="settinglabel settingcell">
+										<div title="DRY Last N" class="justifyleft settingsmall" style="width:100%">L.Len</div>
+										<div class="justifyleft settingsmall" style="width:100%">
+										<input title="DRY Last N" class="settinglabel miniinput" type="text" inputmode="decimal" placeholder="0.0" value="0.0" id="dry_penalty_last_n"></div>
 									</div>
 								</div>
 								<button id="setbreakers" type="button" class="btn btn-primary" style="width:100%; padding:2px 3px;margin-top:2px;font-size:11px;" onclick="setDryBreakers()">Seq. Breaks</button>

--- a/koboldcpp_api.html
+++ b/koboldcpp_api.html
@@ -244,6 +244,11 @@
                             "minimum": 0,
                             "type": "number"
                          },
+                         "dry_penalty_last_n": {
+                            "description": "KoboldCpp ONLY. DRY last n tokens penalized value.",
+                            "minimum": 0,
+                            "type": "number"
+                         },
                          "dry_sequence_breakers": {
                             "description": "An array of string sequence breakers for DRY.",
                             "items": {

--- a/koboldcpp_api.json
+++ b/koboldcpp_api.json
@@ -234,6 +234,11 @@
 						"minimum": 0,
 						"type": "number"
 					},
+                     "dry_penalty_last_n": {
+                        "description": "KoboldCpp ONLY. DRY last n tokens penalized value.",
+                        "minimum": 0,
+                        "type": "number"
+                     },
 					"dry_sequence_breakers": {
 						"description": "An array of string sequence breakers for DRY.",
 						"items": {


### PR DESCRIPTION
Feature: Add dry_penalty_last_n to samplers tab and docs

This is to address the limitations that rep_pen_range controlling both causes in cases when a user wishes to use both Repetition Penalty and DRY. I tried to follow the format of the existing DRY block without bloating things.

Sorry if I missed anything, but this seemed to be working as intended on my local version (as klite.embd).