### PR TITLE
Save Higher-Res optimized for better image quality. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -3569,7 +3569,7 @@ Current version indicated by LITEVER below.
 	const OAI_TTS_ID = 5;
 	const POLLINATIONS_TTS_ID = 6;
 
-	const HD_RES_PX = 768;
+	const HD_RES_PX = 1024;
 	const VHD_RES_PX = 960;
 	const NO_HD_RES_PX = 512;
 	const PREVIEW_RES_PX = 200;
@@ -20508,7 +20508,11 @@ Current version indicated by LITEVER below.
 		}
 	}
 
-	function compressImage(inputDataUri, onDone, fixedSize=true, maxSize=NO_HD_RES_PX, quality = 0.45, letterboxAspect=false) {
+	function compressImage(inputDataUri, onDone, fixedSize=true, maxSize=NO_HD_RES_PX, quality = 0.35, letterboxAspect=false) {
+		if (maxSize === HD_RES_PX) {
+			quality = 0.6;
+			}
+		
 		let img = document.createElement('img');
 		let wantedWidth = maxSize;
 		let wantedHeight = maxSize;


### PR DESCRIPTION
Save Higher-Res now saves in 1024 0.6 for better image quality, up from 768 0.35. 512 0.35 remains as a choice for file size optimization with toggle off.