### PR TITLE
More careful Tavern imports and prompt construction

### DIFF
--- a/index.html
+++ b/index.html
@@ -5192,7 +5192,7 @@ Current version indicated by LITEVER below.
 		inputtxt = replaceAll(inputtxt,instructsysplaceholder_end.trim(),get_instruct_systag_end(false));
 		return inputtxt;
 	}
-	function replace_noninstruct_placeholders(inputtxt,escape=false,isgametext=true,persistent_countmap=null,original=null)
+	function replace_noninstruct_placeholders(inputtxt,escape=false,isgametext=true,persistent_countmap=null)
 	{
 		let firstopponent = localsettings.chatopponent;
 		if (firstopponent && firstopponent.includes("||$||")) {
@@ -5211,10 +5211,7 @@ Current version indicated by LITEVER below.
 			inputtxt = replaceAll(inputtxt,"{{char}}",(localsettings.chatopponent?firstopponent:defaultchatopponent),true);
 		}
 
-		if(original !== null) //replacing with "" is allowed
-		{
-			inputtxt = replaceAll(inputtxt,"{{original}}",escape?escape_html(original):original,true);
-		}
+		inputtxt = replaceAll(inputtxt,"{{original}}","",true); //redundant in Lite; use sysprompt or assistant jailbreak instead
 
 		for(let i=0;i<localsettings.placeholder_tags_data.length;++i)
 		{
@@ -5303,12 +5300,12 @@ Current version indicated by LITEVER below.
 	}
 	//if alwaysreplace, then settings are not considered, otherwise checks settings
 	//if isgametext is true, then keeping the random values stable will be prioritized
-	function replace_placeholders(inputtxt, escape=false, alwaysreplace=false, isgametext=true, original=null)
+	function replace_placeholders(inputtxt, escape=false, alwaysreplace=false, isgametext=true)
 	{
 		inputtxt = replace_instruct_placeholders(inputtxt);
 		if(alwaysreplace || localsettings.placeholder_tags)
 		{
-			inputtxt = replace_noninstruct_placeholders(inputtxt,escape,isgametext,null,original);
+			inputtxt = replace_noninstruct_placeholders(inputtxt,escape,isgametext,null);
 		}
 		return inputtxt;
 	}
@@ -9340,7 +9337,7 @@ Current version indicated by LITEVER below.
 			let examplemsg = obj.mes_example?obj.mes_example:"";
 			let sysprompt = obj.system_prompt?obj.system_prompt:"";
 			let personalnotes = obj.creator_notes?obj.creator_notes:"";
-			let authorsnote = obj.post_history_instructions?obj.post_history_instructions:"";
+			let posthistoryinstructions = obj.post_history_instructions?obj.post_history_instructions:"";
 			let greeting = selectedgreeting;
 
 			//post process
@@ -9348,15 +9345,19 @@ Current version indicated by LITEVER below.
 			{
 				scenario = "\n[Scenario: "+scenario+"]";
 			}
+			if(posthistoryinstructions!="")
+			{
+				posthistoryinstructions = "\n[Special Instructions: "+posthistoryinstructions+"]";
+			}
 			if(examplemsg!="")
 			{
-				examplemsg = "\n"+(examplemsg.startsWith("<START>")?"":"<START>\n")+examplemsg;
+				examplemsg = "\n"+(/^<START>\r?\n/.test(examplemsg)?"":"<START>\n")+examplemsg;
 			}
 			if(sysprompt!="")
 			{
 				sysprompt = sysprompt+"\n";
 			}
-			let combinedmem = sysprompt + memory + scenario + examplemsg;
+			let combinedmem = sysprompt + memory + scenario + posthistoryinstructions + examplemsg;
 			let agnaidatafieldsempty = scenario + examplemsg + (obj.personality?obj.personality:"") + greeting;
 			let has_tav_wi_check = has_tavern_wi_check(obj);
 			//check if it's a world info only card, if so, do not restart game
@@ -9379,7 +9380,6 @@ Current version indicated by LITEVER below.
 				localsettings.chatname = myname;
 				localsettings.chatopponent = chatopponent;
 				current_memory = combinedmem + "\n***";
-				current_anote = authorsnote;
 				personal_notes = personalnotes;
 				localsettings.multiline_replies = true;
 				if(usechatmode)
@@ -9578,15 +9578,19 @@ Current version indicated by LITEVER below.
 			{
 				scenario = "\n[Scenario: "+scenario+"]";
 			}
+			if(posthistoryinstructions!="")
+			{
+				posthistoryinstructions = "\n[Special Instructions: "+posthistoryinstructions+"]";
+			}
 			if(examplemsg!="")
 			{
-				examplemsg = "\n"+(examplemsg.startsWith("<START>")?"":"<START>\n")+examplemsg;
+				examplemsg = "\n"+(/^<START>\r?\n/.test(examplemsg)?"":"<START>\n")+examplemsg;
 			}
 			if(sysprompt!="")
 			{
 				sysprompt = sysprompt+"\n";
 			}
-			let combinedmem = sysprompt + memory + scenario + examplemsg;
+			let combinedmem = sysprompt + memory + scenario + posthistoryinstructions + examplemsg;
 			temp_scenario.title = chatopponent;
 			let prev2 = replaceAll(obj.description,"{{char}}",chatopponent,true);
 			prev2 = replaceAll(prev2,"{{user}}","User",true);
@@ -9595,7 +9599,6 @@ Current version indicated by LITEVER below.
 			temp_scenario.prompt = ("\n{{char}}: "+ greeting);
 			temp_scenario.memory = combinedmem;
 			temp_scenario.personalnotes = creatornotes;
-			temp_scenario.authorsnote = posthistoryinstructions;
 
 			//since cai format has no wi, try to grab it from tavern format
 			let myname = ((localsettings.chatname && localsettings.chatname!="")?localsettings.chatname:"User");
@@ -9845,14 +9848,14 @@ Current version indicated by LITEVER below.
 			current_anote = temp_scenario.authorsnote;
 			if(!localsettings.placeholder_tags)
 			{
-				current_anote = replace_placeholders(current_anote, false, true, false, (localsettings.opmode===4)?localsettings.custom_jailbreak_text:"");
+				current_anote = replace_placeholders(current_anote, false, true, false);
 			}
 		}
 		if (temp_scenario.memory != "") {
 			current_memory = temp_scenario.memory;
 			if(!localsettings.placeholder_tags)
 			{
-				current_memory = replace_placeholders(current_memory, false, true, false, (localsettings.opmode===4)?localsettings.instruct_sysprompt:"");
+				current_memory = replace_placeholders(current_memory, false, true, false);
 			}
 		}
 		if (temp_scenario.image && temp_scenario.image != "") {
@@ -15927,15 +15930,16 @@ Current version indicated by LITEVER below.
 			return current_memory;
 		}
 		let basictrunc = to_boundary?substring_to_boundary:((str,len) => str.substring(str.length-len));
-		let startidx = current_memory.indexOf("<START>"); //start of examplemsg
-		if(startidx === -1) {
+		let examplemsg = current_memory.match(/<START>\r?\n/);
+		if(!examplemsg) {
 			return basictrunc(current_memory, max_mem_len);
 		}
+		let examplemsgstart = examplemsg.index+examplemsg[0].length;
 		let suffix = current_memory.endsWith("\n***")?"\n***":"";
-		if(max_mem_len < startidx+7+suffix.length) { //discard all examplemsg
-			return basictrunc(current_memory.substring(0,startidx)+suffix,max_mem_len);
+		if(max_mem_len < examplemsgstart+suffix.length) { //discard all examplemsg
+			return basictrunc(current_memory.substring(0,examplemsg.index)+suffix,max_mem_len);
 		}
-		return current_memory.substring(0,startidx+7)+basictrunc(currrent_memory.substring(startidx+7),max_mem_len-startidx-7);
+		return current_memory.substring(0,examplemsgstart)+basictrunc(currrent_memory.substring(examplemsgstart),max_mem_len-examplemsgstart);
 	}
 		
 	var warn_unsaved = false;
@@ -17769,7 +17773,7 @@ Current version indicated by LITEVER below.
 						{
 							pending_context_preinjection = pending_context_preinjection + localsettings.start_thinking_tag.replaceAll("\\n", "\n") + "\n\n" + localsettings.stop_thinking_tag.replaceAll("\\n", "\n");
 						}
-						if(localsettings.inject_jailbreak_instruct && (!localsettings.placeholder_tags || !current_anote.includes("\{\{original\}\}")))
+						if(localsettings.inject_jailbreak_instruct)
 						{
 							pending_context_preinjection = pending_context_preinjection + localsettings.custom_jailbreak_text.replaceAll("\\n", "\n");
 						}
@@ -17800,7 +17804,7 @@ Current version indicated by LITEVER below.
 			let max_anote_len = Math.floor(max_allowed_characters*0.6);
 			let max_wi_len = Math.floor(max_allowed_characters*0.5);
 			let appendedsysprompt = "";
-			if(localsettings.opmode==4 && localsettings.instruct_sysprompt!="" && (!localsettings.placeholder_tags || !current_memory.includes("\{\{original\}\}")))
+			if(localsettings.opmode==4 && localsettings.instruct_sysprompt!="")
 			{
 				max_mem_len = Math.floor(max_allowed_characters*0.7);
 				appendedsysprompt = get_instruct_systag(false) + localsettings.instruct_sysprompt;
@@ -18030,8 +18034,8 @@ Current version indicated by LITEVER below.
 			//only do this processing if memory or anote is not blank
 			if (truncated_memory.length > 0 || current_anote.length > 0)
 			{
-				truncated_memory = replace_placeholders(truncated_memory,false,false,true,(localsettings.opmode===4)?localsettings.instruct_sysprompt:"");
-				truncated_anote = replace_placeholders(truncated_anote,false,false,false,(localsettings.opmode===4)?localsettings.custom_jailbreak_text:"");
+				truncated_memory = replace_placeholders(truncated_memory,false,false,true);
+				truncated_anote = replace_placeholders(truncated_anote,false,false,false);
 				if(!is_using_kcpp_with_added_memory())
 				{
 					let augmented_len = truncated_memory.length + truncated_context.length + truncated_anote.length;


### PR DESCRIPTION
This PR contains a bunch of tweaks to handle some edge-cases that I've run up against in Lite while messing around with (third-party) Tavern cards, and which I figure would be worth upstreaming. (Since each of these changes are relatively small, I've put them all together.)

---

1. **Alias-handling causes `undefined` to appear in the memory**

Fixes a bug occuring in `function load_temp_scenario_from_tavernobj(obj)` when `examplemsg==""` and the alias `obj.mesExample` is undefined.

2. **"Smarter" memory truncation that prioritizes pruning example messages**

When the memory gets too large for the context, Lite's current behavior is to truncate from the start (using `substring_to_boundary()` or the `substring` method). However, the [V1 character card spec](https://github.com/malfoyslastname/character-card-spec-v2/blob/main/spec_v1.md) recommends pruning example messages (which Lite currently places at the *end* of memory), and the botmaking community [seems to take for granted that examples will be pruned before the main description](https://rentry.org/NG_Context2RAGs#character-description-advanced-definitions).
Personally, I also agree that pruning `examplemsg` first before touching the main memory makes sense (I don't think I've ever wished otherwise), so I've written a function `truncate_memory()` that opportunistically starts truncating from the first example message (detected by the `"<START>"` string, which should occur at the start of `examplemsg`, but we manually prefix it if not).

3. **Import v2 fields**

The current Tavern card loader discards the [v2 fields](https://github.com/malfoyslastname/character-card-spec-v2/blob/main/spec_v2.md) `creator_notes` and `post_history_instructions`, even though they often contain useful details. I propose to import and put them in the (currently unused) "Personal Notes" and "Author's Note" fields, which seems to match how they're intended to be used (both by the spec, as well as in practice).

(I've also taken the opportunity to change the header for the `obj.description` field to `"Description: "` from `"Persona: "` (Tavern only, other formats unchanged), since there are several Tavern cards where {{char}} is not a character but a setting, and this field really is intended to be a description.)

4. **Handling the `{{original}}` placeholder**

As described in the v2 spec above. Personally I think it's silly to have a placeholder with two different meanings (depending on whether it appears in the `system_prompt` or `post_history_instructions` field), but I have seen cards using it in the wild, so we might as well handle it properly.

From what I understand, it's meant to be replaced with the user's current system prompt or jailbreak (both of which are only activated in Instruct Mode). My proposal is to add the following logic to the `replace_noninstruct_placeholders()` function:
- If the user is not in Instruct Mode, replace `{{original}}` with the empty string `""`;
- If the user is in Instruct Mode, and there is at least one occurrence of `{{original}}` in the memory or A/N (i.e., `system_prompt` or `post_history_instructions`), then we replace it with the Lite system prompt or assistant jailbreak respectively. Hence, when assembling the Instruct prompt for submission, we can skip over the injection of the sysprompt/jailbreak.

---

All these should help to reduce the gap between the out-of-box user experience of chatting with Tavern cards in Lite, and the experience intended by the cardwriter (who is unlikely to be writing with Lite in mind).