### PR TITLE
Custom sampler presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -5480,10 +5480,15 @@ Current version indicated by LITEVER below.
 		// load custom sampler presets
 		if (loadedsamplerpresetsjson != null && loadedsamplerpresetsjson != "") {
 			let loadedsamplerpresets = JSON.parse(loadedsamplerpresetsjson);
-			let custompresets = Object.values(loadedsamplerpresets).map((p) => { p.is_custom = true; return p; });
-			samplerpresets.push(...custompresets);
-			console.log(`Loaded ${custompresets.length} custom sampler presets`);
+			let custompresets = Object.keys(loadedsamplerpresets).map((k) => {
+				let p = loadedsamplerpresets[k];
+				p.is_custom = true;
+				return p;
+			});
+			samplerpresets.push.apply(samplerpresets, custompresets);
+			console.log("Loaded " + custompresets.length + " custom sampler presets");
 		}
+
 
 	} catch (e) {
 		console.log("Discarded invalid local save: " + e);
@@ -15346,7 +15351,7 @@ Current version indicated by LITEVER below.
 			}
 			npresets += `<option value="` + i + `" title="` + samplerpresets[i].description + `">` + samplerpresets[i].preset + `</option>`;
 		}
-		var custom_idx = 1000; 
+		var custom_idx = 1000;
 		for (i; i < samplerpresets.length; ++i, ++custom_idx) { // then the custom ones
 			npresets += `<option value="` + custom_idx + `" title="` + samplerpresets[i].description + `">` + samplerpresets[i].preset + `</option>`;
 		}
@@ -15522,20 +15527,19 @@ Current version indicated by LITEVER below.
 			document.getElementById("presetsdesc").innerText = found.description;
 			document.getElementById("dynatemp_overview").innerText = (document.getElementById("dynatemp_range").value!=0?"ON":"OFF");
 			document.getElementById("second_ep_overview").innerText = (document.getElementById("second_ep_qty").value>0 && document.getElementById("second_ep_url").value!=""?"ON":"OFF");
-			// setting these for local/remote Koboldcpp, defaults otherwise (these don't get set as no samplers use them in remote APIs)
-			let is_kccpd = document.getElementById("customapidropdown").value === "1";
-			document.getElementById("miro_type").value = is_kccpd? found.miro_type ?? 0 : 0;
-			document.getElementById("dry_multiplier").value = is_kccpd? found.dry_multiplier ?? 0 : 0;
-			document.getElementById("xtc_probability").value = is_kccpd? found.xtc_probability ?? 0 : 0;
-			document.getElementById("sampler_seed").value = is_kccpd? found.sampler_seed ?? -1 : -1;
-			document.getElementById("miro_tau").value = is_kccpd? found.miro_tau ?? defaultsettings.miro_tau : defaultsettings.miro_tau;
-			document.getElementById("miro_eta").value = is_kccpd? found.miro_eta ?? defaultsettings.miro_eta : defaultsettings.miro_eta;
-			document.getElementById("dry_base").value = is_kccpd? found.dry_base ?? defaultsettings.dry_base : defaultsettings.dry_base;
-			document.getElementById("dry_allowed_length").value = is_kccpd? found.dry_allowed_length ?? defaultsettings.dry_allowed_length : defaultsettings.dry_allowed_length;
-			document.getElementById("dry_penalty_last_n").value = is_kccpd? found.dry_penalty_last_n ?? defaultsettings.dry_penalty_last_n : defaultsettings.dry_penalty_last_n;
-			document.getElementById("xtc_threshold").value = is_kccpd? found.xtc_threshold ?? defaultsettings.xtc_threshold : defaultsettings.xtc_threshold;
-			document.getElementById("adaptivep_target").value = is_kccpd? found.adaptivep_target ?? defaultsettings.adaptivep_target : defaultsettings.adaptivep_target;
-			document.getElementById("adaptivep_decay").value = is_kccpd? found.adaptivep_decay ?? defaultsettings.adaptivep_decay : defaultsettings.adaptivep_decay;
+			// note: these samplers are only used in koboldcpp
+			document.getElementById("miro_type").value = found.miro_type ? found.miro_type : defaultsettings.miro_type;
+			document.getElementById("dry_multiplier").value = found.dry_multiplier ? found.dry_multiplier : defaultsettings.dry_multiplier;
+			document.getElementById("xtc_probability").value = found.xtc_probability ? found.xtc_probability : defaultsettings.xtc_probability;
+			document.getElementById("sampler_seed").value = found.sampler_seed ? found.sampler_seed : defaultsettings.sampler_seed;
+			document.getElementById("miro_tau").value = found.miro_tau ? found.miro_tau : defaultsettings.miro_tau;
+			document.getElementById("miro_eta").value = found.miro_eta ? found.miro_eta : defaultsettings.miro_eta;
+			document.getElementById("dry_base").value = found.dry_base ? found.dry_base : defaultsettings.dry_base;
+			document.getElementById("dry_allowed_length").value = found.dry_allowed_length ? found.dry_allowed_length : defaultsettings.dry_allowed_length;
+			document.getElementById("dry_penalty_last_n").value = found.dry_penalty_last_n ? found.dry_penalty_last_n : defaultsettings.dry_penalty_last_n;
+			document.getElementById("xtc_threshold").value = found.xtc_threshold ? found.xtc_threshold : defaultsettings.xtc_threshold;
+			document.getElementById("adaptivep_target").value = found.adaptivep_target ? found.adaptivep_target : defaultsettings.adaptivep_target;
+			document.getElementById("adaptivep_decay").value = found.adaptivep_decay ? found.adaptivep_decay : defaultsettings.adaptivep_decay;
 			if (found.is_custom) {
 				document.getElementById("btn_delete_samplerpreset").disabled = false;
 			}
@@ -15545,16 +15549,23 @@ Current version indicated by LITEVER below.
 	}
 
 	function store_samplerpresets() {
-		const data = samplerpresets.filter((p) => p.is_custom === true)
-			.map((p) => { 
-				let p_copy = {...p};
-				delete p_copy.is_custom; 
-				return p_copy; 
-			})
-			.reduce((acc, p) => { acc[p.preset] = p; return acc; }, {});
+		let data = samplerpresets.filter(function (p) {
+			return p.is_custom === true;
+		}).map(function (p) {
+			var p_copy = {};
+			for (var k in p) {
+				if (p.hasOwnProperty(k)) {
+					p_copy[k] = p[k];
+				}
+			}
+			delete p_copy.is_custom;
+			return p_copy;
+		}).reduce(function (acc, p) {
+			acc[p.preset] = p;
+			return acc;
+		}, {});
 
-		indexeddb_save("samplerpresets", JSON.stringify(data))
-			.catch((e) => console.error("Failed to save sampler presets to IndexedDB."));
+		indexeddb_save("samplerpresets", JSON.stringify(data)).catch((e) => console.error("Failed to save sampler presets to IndexedDB."));
 	}
 
 	function save_sampler_preset() {
@@ -15622,9 +15633,9 @@ Current version indicated by LITEVER below.
 		const new_option = new Option(presetname, new_value, false, true);
 		new_option.title = newpreset.description;
 		if (custom_option) {
-				custom_option.before(new_option);
+			custom_option.parentNode.insertBefore(new_option, custom_option);
 		} else {
-				document.getElementById('samplerpresets').add(new_option);
+			document.getElementById('samplerpresets').add(new_option);
 		}
 
 		document.getElementById("samplerpresets").value = new_value;
@@ -15703,7 +15714,7 @@ Current version indicated by LITEVER below.
 
 	//check if any setting is modified from current preset, and set to custom if so
 	function setting_tweaked() {
-		var p_sel = document.getElementById("samplerpresets");		
+		var p_sel = document.getElementById("samplerpresets");
 		if (p_sel.value == 9999) {
 			document.getElementById("presetsdesc").innerText = "Custom settings with modified settings.";
 			return;
@@ -15730,18 +15741,18 @@ Current version indicated by LITEVER below.
 			document.getElementById("rep_pen_slope").value != found.rep_pen_slope ||
 			document.getElementById("sampler_order").value != found.sampler_order.toString()) ||
 
-			document.getElementById("miro_type").value != (found.miro_type ?? 0) ||
-			document.getElementById("dry_multiplier").value != (found.dry_multiplier ?? 0) ||
-			document.getElementById("xtc_probability").value != (found.xtc_probability ?? 0) ||
-			document.getElementById("sampler_seed").value != (found.sampler_seed ?? -1) ||
-			document.getElementById("miro_tau").value != (found.miro_tau ?? defaultsettings.miro_tau) ||
-			document.getElementById("miro_eta").value != (found.miro_eta ?? defaultsettings.miro_eta) ||
-			document.getElementById("dry_base").value != (found.dry_base ?? defaultsettings.dry_base) ||
-			document.getElementById("dry_allowed_length").value != (found.dry_allowed_length ?? defaultsettings.dry_allowed_length) ||
-			document.getElementById("dry_penalty_last_n").value != (found.dry_penalty_last_n ?? defaultsettings.dry_penalty_last_n) ||
-			document.getElementById("xtc_threshold").value != (found.xtc_threshold ?? defaultsettings.xtc_threshold) ||
-			document.getElementById("adaptivep_target").value != (found.adaptivep_target ?? defaultsettings.adaptivep_target) ||
-			document.getElementById("adaptivep_decay").value != (found.adaptivep_decay ?? defaultsettings.adaptivep_decay);
+			document.getElementById("miro_type").value != (found.miro_type != null ? found.miro_type : defaultsettings.miro_type) ||
+			document.getElementById("dry_multiplier").value != (found.dry_multiplier != null ? found.dry_multiplier : defaultsettings.dry_multiplier) ||
+			document.getElementById("xtc_probability").value != (found.xtc_probability != null ? found.xtc_probability : defaultsettings.xtc_probability) ||
+			document.getElementById("sampler_seed").value != (found.sampler_seed != null ? found.sampler_seed : defaultsettings.sampler_seed) ||
+			document.getElementById("miro_tau").value != (found.miro_tau != null ? found.miro_tau : defaultsettings.miro_tau) ||
+			document.getElementById("miro_eta").value != (found.miro_eta != null ? found.miro_eta : defaultsettings.miro_eta) ||
+			document.getElementById("dry_base").value != (found.dry_base != null ? found.dry_base : defaultsettings.dry_base) ||
+			document.getElementById("dry_allowed_length").value != (found.dry_allowed_length != null ? found.dry_allowed_length : defaultsettings.dry_allowed_length) ||
+			document.getElementById("dry_penalty_last_n").value != (found.dry_penalty_last_n != null ? found.dry_penalty_last_n : defaultsettings.dry_penalty_last_n) ||
+			document.getElementById("xtc_threshold").value != (found.xtc_threshold != null ? found.xtc_threshold : defaultsettings.xtc_threshold) ||
+			document.getElementById("adaptivep_target").value != (found.adaptivep_target != null ? found.adaptivep_target : defaultsettings.adaptivep_target) ||
+			document.getElementById("adaptivep_decay").value != (found.adaptivep_decay != null ? found.adaptivep_decay : defaultsettings.adaptivep_decay);
 
 			if(changed)
 			{


### PR DESCRIPTION
I've added functionality for users to save/delete custom sampler presets.

It consists in two new buttons next to the presets select in the "Settings > Samplers" window: Save / Delete.

New custom presets are saved to IndexedDB under the 'samplerpresets' key.
When Koboldcpp starts, the existing presets will be loaded and put after the predefined ones in the select element. Still, the [Custom] preset is put at the end.
For separation and easiness to handle them in some parts of the code, the custom ones are put in the select with values between 1000 and 9998. 
At the same time, they are put in the 'samplerspresets' array with the same properties as the predefined ones, plus a new one only for the custom ones: is_custom: true.

This allows us to detect when a selected preset is custom or not. If it is, the "Delete" button is enabled, otherwise it remains disabled.

Also, I have made the samplers at the bottom, like Mirostats, DRYs, XTCs, be saved, and populated to their UI elements when we are connected to a custom Koboldcpp endpoint. 
