### PR TITLE
add ui samplersets validation before save preset

### DIFF
--- a/index.html
+++ b/index.html
@@ -15513,39 +15513,47 @@ Current version indicated by LITEVER below.
 		let p_value = p_select.value;
 		let found = samplerpresets.find(p => p.preset === p_name);
 		if (found) {
+			document.getElementById("presetsdesc").innerText = found.description;
 			document.getElementById("temperature").value = document.getElementById("temperature_slide").value = found.temp;
-			document.getElementById("presence_penalty").value = found.presence_penalty;
-			document.getElementById("min_p").value = found.min_p;
-			document.getElementById("dynatemp_range").value = found.dynatemp_range;
-			document.getElementById("dynatemp_exponent").value = found.dynatemp_exponent;
-			document.getElementById("smoothing_factor").value = found.smoothing_factor;
-			document.getElementById("smoothing_curve").value = found.smoothing_curve;
-			document.getElementById("nsigma").value = found.nsigma;
-			document.getElementById("top_k").value = document.getElementById("top_k_slide").value = found.top_k;
+			document.getElementById("rep_pen").value = document.getElementById("rep_pen_slide").value = found.rep_pen;
 			document.getElementById("top_p").value = document.getElementById("top_p_slide").value = found.top_p;
+			document.getElementById("top_k").value = document.getElementById("top_k_slide").value = found.top_k;
+			// advanced samplers
+			document.getElementById("eos_ban_mode").value = found.eos_ban_mode || defaultsettings.eos_ban_mode;
+			document.getElementById("token_count_multiplier").value = found.token_count_multiplier || defaultsettings.token_count_multiplier;
+			document.getElementById("sampler_order").value = found.sampler_order.toString();
 			document.getElementById("top_a").value = found.top_a;
 			document.getElementById("typ_s").value = found.typical;
 			document.getElementById("tfs_s").value = found.tfs;
-			document.getElementById("rep_pen").value = document.getElementById("rep_pen_slide").value = found.rep_pen;
+			document.getElementById("min_p").value = found.min_p;
+			document.getElementById("presence_penalty").value = found.presence_penalty;
+			document.getElementById("sampler_seed").value = found.sampler_seed ? found.sampler_seed : defaultsettings.sampler_seed;
 			document.getElementById("rep_pen_range").value = found.rep_pen_range;
 			document.getElementById("rep_pen_slope").value = found.rep_pen_slope;
-			document.getElementById("sampler_order").value = found.sampler_order.toString();
-			document.getElementById("presetsdesc").innerText = found.description;
+			document.getElementById("smoothing_factor").value = found.smoothing_factor;
+			document.getElementById("smoothing_curve").value = found.smoothing_curve;
+			document.getElementById("dynatemp_range").value = found.dynatemp_range;
+			document.getElementById("dynatemp_exponent").value = found.dynatemp_exponent;
 			document.getElementById("dynatemp_overview").innerText = (document.getElementById("dynatemp_range").value!=0?"ON":"OFF");
+			document.getElementById("second_ep_qty").value = found.second_ep_qty || defaultsettings.second_ep_qty;
+			document.getElementById("second_ep_model").value = found.second_ep_model || defaultsettings.second_ep_model;
+			document.getElementById("second_ep_url").value = found.second_ep_url || defaultsettings.second_ep_url;
 			document.getElementById("second_ep_overview").innerText = (document.getElementById("second_ep_qty").value>0 && document.getElementById("second_ep_url").value!=""?"ON":"OFF");
 			// note: these samplers are only used in koboldcpp
 			document.getElementById("miro_type").value = found.miro_type ? found.miro_type : defaultsettings.miro_type;
-			document.getElementById("dry_multiplier").value = found.dry_multiplier ? found.dry_multiplier : defaultsettings.dry_multiplier;
-			document.getElementById("xtc_probability").value = found.xtc_probability ? found.xtc_probability : defaultsettings.xtc_probability;
-			document.getElementById("sampler_seed").value = found.sampler_seed ? found.sampler_seed : defaultsettings.sampler_seed;
 			document.getElementById("miro_tau").value = found.miro_tau ? found.miro_tau : defaultsettings.miro_tau;
 			document.getElementById("miro_eta").value = found.miro_eta ? found.miro_eta : defaultsettings.miro_eta;
+			document.getElementById("dry_multiplier").value = found.dry_multiplier ? found.dry_multiplier : defaultsettings.dry_multiplier;
 			document.getElementById("dry_base").value = found.dry_base ? found.dry_base : defaultsettings.dry_base;
 			document.getElementById("dry_allowed_length").value = found.dry_allowed_length ? found.dry_allowed_length : defaultsettings.dry_allowed_length;
 			document.getElementById("dry_penalty_last_n").value = found.dry_penalty_last_n ? found.dry_penalty_last_n : defaultsettings.dry_penalty_last_n;
+			pendingsequencebreakers = found.dry_sequence_breakers || defaultsettings.dry_sequence_breakers;
 			document.getElementById("xtc_threshold").value = found.xtc_threshold ? found.xtc_threshold : defaultsettings.xtc_threshold;
+			document.getElementById("xtc_probability").value = found.xtc_probability ? found.xtc_probability : defaultsettings.xtc_probability;
 			document.getElementById("adaptivep_target").value = found.adaptivep_target ? found.adaptivep_target : defaultsettings.adaptivep_target;
 			document.getElementById("adaptivep_decay").value = found.adaptivep_decay ? found.adaptivep_decay : defaultsettings.adaptivep_decay;
+			document.getElementById("nsigma").value = found.nsigma;
+			pendinggrammar = found.grammar || defaultsettings.grammar
 		} else {
 			document.getElementById("presetsdesc").innerText = "";
 		}
@@ -15609,40 +15617,77 @@ Current version indicated by LITEVER below.
 			return;
 		}
 
+		document.getElementById("temperature").value = cleannum(parseFloat(document.getElementById("temperature").value), 0.01, 5);
+		document.getElementById("rep_pen").value = cleannum(parseFloat(document.getElementById("rep_pen").value), 0.1, 5);
+		document.getElementById("top_p").value = cleannum(parseFloat(document.getElementById("top_p").value), 0.002, 1);
+		document.getElementById("top_k").value = cleannum(Math.floor(parseInt(document.getElementById("top_k").value, 10)), 0, 300);
+		document.getElementById("top_a").value = cleannum(parseFloat(document.getElementById("top_a").value), 0, 1);
+		document.getElementById("typ_s").value = cleannum(parseFloat(document.getElementById("typ_s").value), 0, 1);
+		document.getElementById("tfs_s").value = cleannum(parseFloat(document.getElementById("tfs_s").value), 0, 1);
+		document.getElementById("min_p").value = cleannum(parseFloat(document.getElementById("min_p").value), 0.0, 1);
+		document.getElementById("presence_penalty").value = cleannum(parseFloat(document.getElementById("presence_penalty").value), -2, 2);
+		document.getElementById("sampler_seed").value = cleannum(parseFloat(document.getElementById("sampler_seed").value), -1, 999999);
+		document.getElementById("rep_pen_range").value = cleannum(parseFloat(document.getElementById("rep_pen_range").value), 0, localsettings.max_context_length);
+		document.getElementById("rep_pen_slope").value = cleannum(parseFloat(document.getElementById("rep_pen_slope").value), 0, 20);
+		document.getElementById("smoothing_factor").value = cleannum(parseFloat(document.getElementById("smoothing_factor").value), 0.0, 10.0);
+		document.getElementById("smoothing_curve").value = cleannum(parseFloat(document.getElementById("smoothing_curve").value), 0.1, 5.0);
+		document.getElementById("miro_type").value = cleannum(parseFloat(document.getElementById("miro_type").value), 0, 2);
+		document.getElementById("miro_tau").value = cleannum(parseFloat(document.getElementById("miro_tau").value), 0, 30);
+		document.getElementById("miro_eta").value = cleannum(parseFloat(document.getElementById("miro_eta").value), 0, 10);
+		document.getElementById("dry_multiplier").value = cleannum(parseFloat(document.getElementById("dry_multiplier").value), 0.0, 100.0);
+		document.getElementById("dry_base").value = cleannum(parseFloat(document.getElementById("dry_base").value), 0.0, 8.0);
+		document.getElementById("dry_allowed_length").value = cleannum(parseFloat(document.getElementById("dry_allowed_length").value)(localsettings.dry_allowed_length), 0, 100);
+		document.getElementById("dry_penalty_last_n").value = cleannum(parseFloat(document.getElementById("dry_penalty_last_n").value), 0.0, localsettings.max_context_length);
+		document.getElementById("xtc_threshold").value = cleannum(parseFloat(document.getElementById("xtc_threshold").value), 0.0, 1.0);
+		document.getElementById("xtc_probability").value = cleannum(parseFloat(document.getElementById("xtc_probability").value), 0.0, 1.0);
+		document.getElementById("adaptivep_target").value = cleannum(parseFloat(document.getElementById("adaptivep_target").value), -1, 1);
+		document.getElementById("adaptivep_decay").value = cleannum(parseFloat(document.getElementById("adaptivep_decay").value), 0.01, 0.99);
+		document.getElementById("nsigma").value = cleannum(parseFloat(document.getElementById("nsigma").value), 0.0, 5.0);
+		document.getElementById("dynatemp_range").value = cleannum(parseFloat(document.getElementById("dynatemp_range").value), -5, 5);
+		document.getElementById("dynatemp_exponent").value = cleannum(parseFloat(document.getElementById("dynatemp_exponent").value), 0.0, 10.0);
+
 		let newpreset = {
 			is_custom: true,
 			preset: presetname,
 			description: document.getElementById("sampler_preset_description").value.trim(),
 			temp: parseFloat(document.getElementById("temperature").value),
-			dynatemp_range: parseFloat(document.getElementById("dynatemp_range").value),
-			dynatemp_exponent: parseFloat(document.getElementById("dynatemp_exponent").value),
-			smoothing_factor: parseFloat(document.getElementById("smoothing_factor").value),
-			smoothing_curve: parseFloat(document.getElementById("smoothing_curve").value),
-			nsigma: parseFloat(document.getElementById("nsigma").value),
-			top_k: parseInt(document.getElementById("top_k").value, 10),
+			rep_pen: parseFloat(document.getElementById("rep_pen").value),
 			top_p: parseFloat(document.getElementById("top_p").value),
-			min_p: parseFloat(document.getElementById("min_p").value),
-			presence_penalty: parseFloat(document.getElementById("presence_penalty").value),
+			top_k: parseInt(document.getElementById("top_k").value, 10),
+
+			eos_ban_mode: document.getElementById("eos_ban_mode").value,
+			token_count_multiplier: document.getElementById("token_count_multiplier").value,
+			sampler_order: document.getElementById("sampler_order").value.split(",").map(x => parseInt(x, 10)),
 			top_a: parseFloat(document.getElementById("top_a").value),
 			typical: parseFloat(document.getElementById("typ_s").value),
 			tfs: parseFloat(document.getElementById("tfs_s").value),
-			rep_pen: parseFloat(document.getElementById("rep_pen").value),
+			min_p: parseFloat(document.getElementById("min_p").value),
+			presence_penalty: parseFloat(document.getElementById("presence_penalty").value),
+			sampler_seed: parseFloat(document.getElementById("sampler_seed").value),
 			rep_pen_range: parseInt(document.getElementById("rep_pen_range").value, 10),
 			rep_pen_slope: parseFloat(document.getElementById("rep_pen_slope").value),
-			sampler_order: document.getElementById("sampler_order").value.split(",").map(x => parseInt(x, 10)),
+			smoothing_factor: parseFloat(document.getElementById("smoothing_factor").value),
+			smoothing_curve: parseFloat(document.getElementById("smoothing_curve").value),
 
 			miro_type: parseFloat(document.getElementById("miro_type").value),
-			dry_multiplier: parseFloat(document.getElementById("dry_multiplier").value),
-			xtc_probability: parseFloat(document.getElementById("xtc_probability").value),
-			sampler_seed: parseFloat(document.getElementById("sampler_seed").value),
 			miro_tau: parseFloat(document.getElementById("miro_tau").value),
 			miro_eta: parseFloat(document.getElementById("miro_eta").value),
+			dry_multiplier: parseFloat(document.getElementById("dry_multiplier").value),
 			dry_base: parseFloat(document.getElementById("dry_base").value),
 			dry_allowed_length: parseFloat(document.getElementById("dry_allowed_length").value),
 			dry_penalty_last_n: parseFloat(document.getElementById("dry_penalty_last_n").value),
+			dry_sequence_breakers: pendingsequencebreakers,
 			xtc_threshold: parseFloat(document.getElementById("xtc_threshold").value),
+			xtc_probability: parseFloat(document.getElementById("xtc_probability").value),
 			adaptivep_target: parseFloat(document.getElementById("adaptivep_target").value),
 			adaptivep_decay: parseFloat(document.getElementById("adaptivep_decay").value),
+			nsigma: parseFloat(document.getElementById("nsigma").value),
+			grammar: pendinggrammar,
+			dynatemp_range: parseFloat(document.getElementById("dynatemp_range").value),
+			dynatemp_exponent: parseFloat(document.getElementById("dynatemp_exponent").value),
+			second_ep_qty: document.getElementById("second_ep_qty").value,
+			second_ep_model: document.getElementById("second_ep_model").value,
+			second_ep_url: document.getElementById("second_ep_url").value,
 		};
 
 		samplerpresets.push(newpreset);
@@ -16278,21 +16323,21 @@ Current version indicated by LITEVER below.
 		localsettings.max_length = cleannum(localsettings.max_length, 1, Math.floor(localsettings.max_context_length*0.85)); //clamp to max 85% of max ctx
 		localsettings.temperature = cleannum(localsettings.temperature, 0.01, 5);
 		localsettings.rep_pen = cleannum(localsettings.rep_pen, 0.1, 5);
-		localsettings.rep_pen_range = cleannum(localsettings.rep_pen_range, 0, localsettings.max_context_length);
-		localsettings.rep_pen_slope = cleannum(localsettings.rep_pen_slope, 0, 20);
 		localsettings.top_p = cleannum(localsettings.top_p, 0.002, 1);
-		localsettings.min_p = cleannum(localsettings.min_p, 0.0, 1);
-		localsettings.dynatemp_range = cleannum(localsettings.dynatemp_range, -5, 5);
-		localsettings.dynatemp_range = ((localsettings.dynatemp_range > localsettings.temperature) ? localsettings.temperature : ((localsettings.dynatemp_range < -localsettings.temperature) ? -localsettings.temperature : localsettings.dynatemp_range));
-		localsettings.dynatemp_exponent = cleannum(localsettings.dynatemp_exponent, 0.0, 10.0);
-		localsettings.smoothing_factor = cleannum(localsettings.smoothing_factor, 0.0, 10.0);
-		localsettings.smoothing_curve = cleannum(localsettings.smoothing_curve, 0.1, 5.0);
-		localsettings.nsigma = cleannum(localsettings.nsigma, 0.0, 5.0);
-		localsettings.presence_penalty = cleannum(localsettings.presence_penalty, -2, 2);
 		localsettings.top_k = cleannum(Math.floor(localsettings.top_k), 0, 300);
+		// advanced samplers
+		localsettings.token_count_multiplier = cleannum(localsettings.token_count_multiplier, 70, 130);
 		localsettings.top_a = cleannum(localsettings.top_a, 0, 1);
 		localsettings.typ_s = cleannum(localsettings.typ_s, 0, 1);
 		localsettings.tfs_s = cleannum(localsettings.tfs_s, 0, 1);
+		localsettings.min_p = cleannum(localsettings.min_p, 0.0, 1);
+		localsettings.presence_penalty = cleannum(localsettings.presence_penalty, -2, 2);
+		localsettings.sampler_seed = cleannum(localsettings.sampler_seed, -1, 999999);
+		localsettings.rep_pen_range = cleannum(localsettings.rep_pen_range, 0, localsettings.max_context_length);
+		localsettings.rep_pen_slope = cleannum(localsettings.rep_pen_slope, 0, 20);
+		localsettings.smoothing_factor = cleannum(localsettings.smoothing_factor, 0.0, 10.0);
+		localsettings.smoothing_curve = cleannum(localsettings.smoothing_curve, 0.1, 5.0);
+		// samplers only used in koboldcpp
 		localsettings.miro_type = cleannum(localsettings.miro_type, 0, 2);
 		localsettings.miro_tau = cleannum(localsettings.miro_tau, 0, 30);
 		localsettings.miro_eta = cleannum(localsettings.miro_eta, 0, 10);
@@ -16300,12 +16345,14 @@ Current version indicated by LITEVER below.
 		localsettings.dry_base = cleannum(localsettings.dry_base, 0.0, 8.0);
 		localsettings.dry_allowed_length = cleannum(Math.floor(localsettings.dry_allowed_length), 0, 100);
 		localsettings.dry_penalty_last_n = cleannum(localsettings.dry_penalty_last_n, 0.0, localsettings.max_context_length);
-		localsettings.xtc_probability = cleannum(localsettings.xtc_probability, 0.0, 1.0);
 		localsettings.xtc_threshold = cleannum(localsettings.xtc_threshold, 0.0, 1.0);
+		localsettings.xtc_probability = cleannum(localsettings.xtc_probability, 0.0, 1.0);
 		localsettings.adaptivep_target = cleannum(localsettings.adaptivep_target, -1, 1);
 		localsettings.adaptivep_decay = cleannum(localsettings.adaptivep_decay, 0.01, 0.99);
-		localsettings.sampler_seed = cleannum(localsettings.sampler_seed, -1, 999999);
-		localsettings.token_count_multiplier = cleannum(localsettings.token_count_multiplier, 70, 130);
+		localsettings.nsigma = cleannum(localsettings.nsigma, 0.0, 5.0);
+		localsettings.dynatemp_range = cleannum(localsettings.dynatemp_range, -5, 5);
+		localsettings.dynatemp_range = ((localsettings.dynatemp_range > localsettings.temperature) ? localsettings.temperature : ((localsettings.dynatemp_range < -localsettings.temperature) ? -localsettings.temperature : localsettings.dynatemp_range));
+		localsettings.dynatemp_exponent = cleannum(localsettings.dynatemp_exponent, 0.0, 10.0);
 		localsettings.second_ep_qty = cleannum(Math.floor(localsettings.second_ep_qty), 0, 1024);
 		toggle_theme_colors();
 		toggle_sidepanel_mode();


### PR DESCRIPTION
After introducing functionality to save new sampler presets, there is the possibility that a user saves a preset with not valid values for some samplers, causing the UI to switch to the "[Custom]" preset.

## Steps to Replicate
1. Enter "20" in the input box for "Repeat Penalty"
2. Save the preset as "Bad Preset".
3. Click OK to close the Settings popup.
4. Open the Settings popup.

* *Expected behaviour*: The preset "Bad Preset" should be selected and its values populated.
* *Observed behaviour*: The preset "[Custom]" is selected with the values of the "Bad Preset".

## Analysis
Once the user click "OK" to close the Settings popup, the `confirm_settings()` function will adjust that input to 5, but the stored preset will still have 20.  
Next time the user opens Settings, `display_settings() -> settings_tweaked()` will see that there is a difference between the UI value in "Repeat Penalty" and the preset, which will cause the "Sampler Preset" select element to switch to the "[Custom]" preset.

## Changes Introduced
- Added validation of the UI sampler preset elements before saving the preset.  
- Since it was becoming increasingly difficult to handle the different points in the code (JS only) where the related UI elements, preset values, localsetings.xyz are being operated,I have done some refactor in `toggle_preset()`, `save_sampler_preset()` and `confirm_settings()` to follow order of sampler settings as they appear in the UI.