### PR TITLE
hide chat name in messenger theme in instruct mode when not injecting chat names

### DIFF
--- a/index.html
+++ b/index.html
@@ -25742,7 +25742,7 @@ Current version indicated by LITEVER below.
 				curr.msg = render_all_media_html(curr.msg,false,true);
 			}
 
-            var should_display_name = (curr.name && ((localsettings.opmode==4 && localsettings.inject_chatnames_instruct) || localsettings.opmode < 4))
+            var should_display_name = (curr.name && (localsettings.opmode==4 && localsettings.inject_chatnames_instruct) || localsettings.opmode < 4)
 			if(curr.myturn)
 			{
                 let namepart = (should_display_name?`<span style="font-weight: bolder;color:var(--theme_color_user_name);">${escape_html(curr.name)}</span><br>`:"");


### PR DESCRIPTION
looks a lot nicer, especially since without inject chat names, it defaults to the name "KoboldAI".

the way i did it might not be the best way, i couldn't find where the core of the name logic was. i hope this is okay

<img width="526" height="416" alt="image" src="https://github.com/user-attachments/assets/831d5425-f5eb-4d72-a26d-812f49992a87" />
