### PR TITLE
Fix loading a custom sampler settings preset leads to [Custom]

### DIFF
--- a/index.html
+++ b/index.html
@@ -28982,72 +28982,71 @@ Current version indicated by LITEVER below.
 						</div>
 						<div id="presetsdesc" class="settingsdesctxt justifyright"></div>
 
-					<div class="settingsbox flex wide">
-
-						<div class="settingitem">
-							<div class="settinglabel">
-								<div class="justifyleft">Temperature <span class="helpicon">?<span
-											class="helptext">Randomness of sampling. High values can increase creativity but
-											may make text less sensible. Lower values will make text more predictable but
-											can become repetitious.</span></span></div>
-								<input title="Temperature" inputmode="decimal" class="justifyright push-right" id="temperature" value=0.5
-									oninput="document.getElementById('temperature_slide').value = this.value;">
+						<div class="settingsbox flex wide">
+							<div class="settingitem">
+								<div class="settinglabel">
+									<div class="justifyleft">Temperature <span class="helpicon">?<span
+												class="helptext">Randomness of sampling. High values can increase creativity but
+												may make text less sensible. Lower values will make text more predictable but
+												can become repetitious.</span></span></div>
+									<input title="Temperature" inputmode="decimal" class="justifyright push-right" id="temperature" value=0.5
+										oninput="document.getElementById('temperature_slide').value = this.value;">
+								</div>
+								<div><input title="Temperature Slider" type="range" min="0.1" max="2" step="0.01"
+										id="temperature_slide" oninput="
+									document.getElementById('temperature').value = this.value;"></div>
+								<div class="settingminmax">
+									<div class="justifyleft">0.1</div>
+									<div class="justifyright">2</div>
+								</div>
 							</div>
-							<div><input title="Temperature Slider" type="range" min="0.1" max="2" step="0.01"
-									id="temperature_slide" oninput="
-								document.getElementById('temperature').value = this.value;"></div>
-							<div class="settingminmax">
-								<div class="justifyleft">0.1</div>
-								<div class="justifyright">2</div>
+
+							<div class="settingitem">
+								<div class="settinglabel">
+									<div class="justifyleft">Repeat Penalty <span class="helpicon">?<span
+												class="helptext">Used to penalize words that were already generated or belong to
+												the context (too high causes incoherence!).</span></span></div>
+									<input title="Repetition Penalty" inputmode="decimal" class="justifyright push-right" id="rep_pen" oninput="
+									document.getElementById('rep_pen_slide').value = this.value;">
+								</div>
+								<div><input title="Repetition Penalty Slider" type="range" min="1" max="2" step="0.01"
+										id="rep_pen_slide" oninput="document.getElementById('rep_pen').value = this.value;"></div>
+								<div class="settingminmax">
+									<div class="justifyleft">1</div>
+									<div class="justifyright">2</div>
+								</div>
+							</div>
+
+							<div class="settingitem">
+								<div class="settinglabel">
+									<div class="justifyleft">Top-P Sampling <span class="helpicon">?<span class="helptext">Used
+												to discard unlikely text in a nucleus sampling process. Lower values will make text
+												more predictable but can become repetitious. Set to 1 to deactivate it.</span></span></div>
+									<input title="Top-P Sampling" inputmode="decimal" class="justifyright push-right" id="top_p" oninput="
+									document.getElementById('top_p_slide').value = this.value;">
+								</div>
+								<div><input title="Top-P Sampling Slider" type="range" min="0" max="1" step="0.01" id="top_p_slide"
+										oninput="document.getElementById('top_p').value = this.value;"></div>
+								<div class="settingminmax">
+									<div class="justifyleft">0</div>
+									<div class="justifyright">1</div>
+								</div>
+							</div>
+
+							<div class="settingitem">
+								<div class="settinglabel">
+									<div class="justifyleft">Top-K Sampling <span class="helpicon">?<span class="helptext">Top-K Sampling. Discards all but the K most likely tokens. Set 0 to Deactivate. Range 0 to 100.</span></span></div>
+									<input title="Top-K Sampling" inputmode="decimal" class="justifyright push-right" id="top_k" oninput="
+									document.getElementById('top_k_slide').value = this.value;">
+								</div>
+								<div><input title="Top-K Sampling Slider" type="range" min="0" max="100" step="1" id="top_k_slide"
+										oninput="document.getElementById('top_k').value = this.value;"></div>
+								<div class="settingminmax">
+									<div class="justifyleft">0</div>
+									<div class="justifyright">100</div>
+								</div>
 							</div>
 						</div>
-
-						<div class="settingitem">
-							<div class="settinglabel">
-								<div class="justifyleft">Repeat Penalty <span class="helpicon">?<span
-											class="helptext">Used to penalize words that were already generated or belong to
-											the context (too high causes incoherence!).</span></span></div>
-								<input title="Repetition Penalty" inputmode="decimal" class="justifyright push-right" id="rep_pen" oninput="
-								document.getElementById('rep_pen_slide').value = this.value;">
-							</div>
-							<div><input title="Repetition Penalty Slider" type="range" min="1" max="2" step="0.01"
-									id="rep_pen_slide" oninput="document.getElementById('rep_pen').value = this.value;"></div>
-							<div class="settingminmax">
-								<div class="justifyleft">1</div>
-								<div class="justifyright">2</div>
-							</div>
-						</div>
-
-						<div class="settingitem">
-							<div class="settinglabel">
-								<div class="justifyleft">Top-P Sampling <span class="helpicon">?<span class="helptext">Used
-											to discard unlikely text in a nucleus sampling process. Lower values will make text
-											more predictable but can become repetitious. Set to 1 to deactivate it.</span></span></div>
-								<input title="Top-P Sampling" inputmode="decimal" class="justifyright push-right" id="top_p" oninput="
-								document.getElementById('top_p_slide').value = this.value;">
-							</div>
-							<div><input title="Top-P Sampling Slider" type="range" min="0" max="1" step="0.01" id="top_p_slide"
-									oninput="document.getElementById('top_p').value = this.value;"></div>
-							<div class="settingminmax">
-								<div class="justifyleft">0</div>
-								<div class="justifyright">1</div>
-							</div>
-						</div>
-
-						<div class="settingitem">
-							<div class="settinglabel">
-								<div class="justifyleft">Top-K Sampling <span class="helpicon">?<span class="helptext">Top-K Sampling. Discards all but the K most likely tokens. Set 0 to Deactivate. Range 0 to 100.</span></span></div>
-								<input title="Top-K Sampling" inputmode="decimal" class="justifyright push-right" id="top_k" oninput="
-								document.getElementById('top_k_slide').value = this.value;">
-							</div>
-							<div><input title="Top-K Sampling Slider" type="range" min="0" max="100" step="1" id="top_k_slide"
-									oninput="document.getElementById('top_k').value = this.value;"></div>
-							<div class="settingminmax">
-								<div class="justifyleft">0</div>
-								<div class="justifyright">100</div>
-							</div>
-						</div>
-					</div>
 					</div>
 
 					<div class="settingitem wide">


### PR DESCRIPTION
Custom presets with a 0 value in some samplers (eg seed, DRY, XTC, ...) were being evaluated as no value. Fixed to take null as no value, while 0 is still a possible value.

I have also amended the padding of the "Sampler Settings" block to match those of the "Context Settings" and "Advanced Settings" too. 
That required simply moving a `</div>`. 
I also indented the contents of that div html block to avoid confusion in the future. I put this in a separate commit.