### PR TITLE
Add padding to chat message body

### DIFF
--- a/index.html
+++ b/index.html
@@ -761,7 +761,7 @@ Current version indicated by LITEVER below.
 	}
 
 	#chat_msg_body {
-		padding-bottom: 3rem;
+		padding-bottom: 1.5rem;
 	}
 
 

--- a/index.html
+++ b/index.html
@@ -760,6 +760,10 @@ Current version indicated by LITEVER below.
 		}
 	}
 
+	#chat_msg_body {
+		padding-bottom: 3rem;
+	}
+
 
 	/* Viewports */
 	#maineditbody


### PR DESCRIPTION
Does what it says on the tin. Sets #chat_msg_body's padding-bottom to 3rem. This allocates a small bit of breathing room for Chat Mode, when using the Aesthetics theme. I chose 3rem because it looked the best after trying 1rem and 5rem.

I can also implement this for the Corpo and Normal interface themes as well, in this very same PR.