### PR TITLE
Import groupchat participants from character card

### DIFF
--- a/index.html
+++ b/index.html
@@ -11062,6 +11062,7 @@ Current version indicated by LITEVER below.
 			}
 			let chatopponent = obj.name?obj.name:defaultchatopponent;
 			let memory = [obj.description, obj.personality].filter(Boolean).join("\n\n");
+			memory = replaceAll(memory,"{{char}}",chatopponent,true);
 			add_another_participant_from_file({name: chatopponent,ctx_memory:memory,portrait:image_data});
 			return;
 		} 
@@ -11230,6 +11231,7 @@ Current version indicated by LITEVER below.
 		if(to_groupchat)
 		{
 			let memory = obj.char_persona?obj.char_persona:"";
+			memory = replaceAll(memory,"{{char}}",chatopponent,true);
 			add_another_participant_from_file({name:chatopponent,ctx_memory:memory,portrait:null});
 			return;
 		}

--- a/index.html
+++ b/index.html
@@ -10281,7 +10281,7 @@ Current version indicated by LITEVER below.
 				//we don't want to fiddle with the file as its very complex. only handle the parts we are interested in, and just leave the rest untouched.
 				if (is_kai_json(new_loaded_storyobj) && !new_loaded_storyobj.scenarioVersion) {
 					//quick sanity check. if prompt does not exist, this is not a KAI save.
-					kai_json_load(new_loaded_storyobj,false);
+					kai_json_load(new_loaded_storyobj,false, false, true, to_groupchat);
 					if (selectedFilename && selectedFilename != "") {
 						localsettings.last_known_filename = selectedFilename;
 					}
@@ -10298,7 +10298,7 @@ Current version indicated by LITEVER below.
 					}
 					else if(new_loaded_storyobj.md && new_loaded_storyobj.savedsettings) //add some compat loading for sharefiles
 					{
-						kai_json_load(new_loaded_storyobj,false);
+						kai_json_load(new_loaded_storyobj,false, false, true, to_groupchat);
 					}
 					else if(new_loaded_storyobj.scenarioVersion>1 && new_loaded_storyobj.scenarioVersion<10)
 					{
@@ -10349,7 +10349,7 @@ Current version indicated by LITEVER below.
 					try {
 						result = UnzipKAISTORYFile(arr);
 						if (result) {
-							kai_json_load(result, false);
+							kai_json_load(result, false, false, true, to_groupchat);
 							return;
 						}
 					} catch (error) {
@@ -10421,8 +10421,16 @@ Current version indicated by LITEVER below.
 		return is_kai;
 	}
 
-	function kai_json_load(storyobj, force_load_settings, ignore_multiplayer_sync=false, save_after_loading=true)
+	function kai_json_load(storyobj, force_load_settings, ignore_multiplayer_sync=false, save_after_loading=true, to_groupchat=false)
 	{
+		if(to_groupchat)
+		{
+			let chatopponent = storyobj.savedsettings.chatopponent?storyobj.savedsettings.chatopponent:defaultchatopponent;
+			let memory = storyobj.memory?storyobj.memory:"";
+			memory = replaceAll(memory,"{{char}}",chatopponent,true);
+			add_another_participant_from_file({name:chatopponent,ctx_memory:memory,portrait:storyobj.savedaestheticsettings.AI_portrait});
+			return;
+		}
 		//either show popup or just proceed to load
 		handle_advload_popup((localsettings.show_advanced_load && !force_load_settings),()=>
 		{

--- a/index.html
+++ b/index.html
@@ -10248,14 +10248,14 @@ Current version indicated by LITEVER below.
 		return new_save_storyobj;
 	}
 
-	function load_file(event) {
+	function load_file(event, to_groupchat=false) {
 		let input = event.target;
 
 		if (input.files.length > 0) {
 
 			var selectedFile = input.files[0];
 
-			load_selected_file(selectedFile);
+			load_selected_file(selectedFile, to_groupchat);
 
 			document.getElementById("loadfileinput").value = "";
 		} else {
@@ -10264,7 +10264,7 @@ Current version indicated by LITEVER below.
 	};
 
 	//attempt to load a file from disk. could be any format, even images
-	function load_selected_file(selectedFile)
+	function load_selected_file(selectedFile, to_groupchat=false)
 	{
 		var selectedFilename = "";
 		if(selectedFile)
@@ -10290,11 +10290,11 @@ Current version indicated by LITEVER below.
 					let has_tav_wi_check = has_tavern_wi_check(new_loaded_storyobj);
 					if (!new_loaded_storyobj.scenarioVersion && (new_loaded_storyobj.name != null || new_loaded_storyobj.description != null ||
 						new_loaded_storyobj.personality != null || (new_loaded_storyobj.spec=="chara_card_v2" || new_loaded_storyobj.spec=="chara_card_v3") || has_tav_wi_check)) {
-						load_tavern_obj(new_loaded_storyobj);
+						load_tavern_obj(new_loaded_storyobj,to_groupchat);
 					}
 					else if (new_loaded_storyobj.char_name != null || new_loaded_storyobj.char_persona != null) {
 						//check for ooba text generation fields (character)
-						load_ooba_obj(new_loaded_storyobj);
+						load_ooba_obj(new_loaded_storyobj,to_groupchat);
 					}
 					else if(new_loaded_storyobj.md && new_loaded_storyobj.savedsettings) //add some compat loading for sharefiles
 					{
@@ -10324,37 +10324,24 @@ Current version indicated by LITEVER below.
 					const data = pngfr.result;
 					const arr = new Uint8Array(data);
 
-					function setImgAsAvatar(data)
-					{
-						compressImage(data, (compressedImageURI, aspectratio) => {
-							aestheticInstructUISettings.AI_portrait = compressedImageURI;
-							document.getElementById('portrait_ratio_AI').value = aspectratio.toFixed(2);
-							refreshAestheticPreview(true);
-							render_gametext();
-						}, true, AVATAR_PX);
-					}
-
 					// 1. Try Tavern PNG
 					let result = convertTavernPng(arr);
 					if (result) {
-						load_tavern_obj(result);
-						setImgAsAvatar(data);
+						load_tavern_obj(result,to_groupchat,data);
 						return;
 					}
 
 					// 2. Try Tavern EXIF
 					result = getTavernExifJSON(arr);
 					if (result) {
-						load_tavern_obj(result);
-						setImgAsAvatar(data);
+						load_tavern_obj(result,to_groupchat,data);
 						return;
 					}
 
 					// 3. Try Risu V3
 					result = extractRisuData(arr);
 					if (result) {
-						load_tavern_obj(result);
-						setImgAsAvatar(data);
+						load_tavern_obj(result,to_groupchat,data);
 						return;
 					}
 
@@ -11065,8 +11052,19 @@ Current version indicated by LITEVER below.
 		render_gametext(true);
 		sync_multiplayer(true);
 	}
-	function load_tavern_obj(obj)
+	function load_tavern_obj(obj, to_groupchat=false, image_data=null)
 	{
+		if(to_groupchat)
+		{
+			if((obj.spec=="chara_card_v2"||obj.spec=="chara_card_v3") && obj.data!=null)
+			{
+				obj = obj.data;
+			}
+			let chatopponent = obj.name?obj.name:defaultchatopponent;
+			let memory = [obj.description, obj.personality].filter(Boolean).join("\n\n");
+			add_another_participant_from_file({name: chatopponent,ctx_memory:memory,portrait:image_data});
+			return;
+		} 
 		let selectedgreeting = "";
 		let load_tav_obj_confirm_p1 = function(usechatmode) // need second input for alt greeting
 		{
@@ -11214,11 +11212,27 @@ Current version indicated by LITEVER below.
 		{
 			load_tav_obj_confirm_p1(true);
 		}
+		//set image as avatar
+		if(image_data)
+		{
+			compressImage(image_data, (compressedImageURI, aspectratio) => {
+				aestheticInstructUISettings.AI_portrait = compressedImageURI;
+				document.getElementById('portrait_ratio_AI').value = aspectratio.toFixed(2);
+				refreshAestheticPreview(true);
+				render_gametext();
+			}, true, AVATAR_PX);
+		}
 	}
-	function load_ooba_obj(obj)
+	function load_ooba_obj(obj, to_groupchat=false)
 	{
 		console.log("Loading ooba obj");
 		let chatopponent = obj.char_name?obj.char_name:defaultchatopponent;
+		if(to_groupchat)
+		{
+			let memory = obj.char_persona?obj.char_persona:"";
+			add_another_participant_from_file({name:chatopponent,ctx_memory:memory,portrait:null});
+			return;
+		}
 		let myname = ((localsettings.chatname && localsettings.chatname!="")?localsettings.chatname:"User");
 		let memory = obj.char_persona?("Persona: "+obj.char_persona):"";
 		let scenario = obj.world_scenario?obj.world_scenario:"";
@@ -28106,6 +28120,8 @@ Current version indicated by LITEVER below.
 			}
 			gs += `</tbody></table>`;
 			gs += `<br><div class="ui-settings-inline color_blueurl groupchat-inline-action" onclick="add_another_participant(true)">Add AI Participant</div>`;
+			gs+= `<input type="file" id="loadgroupchatinput" accept="*" onchange="load_file(event,true)" style="display:none;">`;
+			gs += `Alternatively, <a href="#" class="color_blueurl groupchat-inline-action" onclick="document.getElementById('loadgroupchatinput').click()"><b>click here to import an existing Tavern Character Card</b></a>.`;
 		}
 		else if(localsettings.opmode==4 && !localsettings.inject_chatnames_instruct)
 		{
@@ -28308,9 +28324,7 @@ Current version indicated by LITEVER below.
 	}
 	function impersonate_message(index)
 	{
-		hide_popups();
-
-		if(localsettings.opmode==3)
+		if(localsettings.opmode==3 || (localsettings.opmode==4 && localsettings.inject_chatnames_instruct))
 		{
 			let grouplist = localsettings.chatopponent.split("||$||");
 			let target = grouplist[index];
@@ -28321,8 +28335,8 @@ Current version indicated by LITEVER below.
 				{
 					gametext_arr.push("\n"+target+": "+userinput);
 					render_gametext();
+					hide_popups();
 				}
-				hide_popups();
 			},false);
 		}
 		else
@@ -28370,6 +28384,31 @@ Current version indicated by LITEVER below.
 				}
 			}
 		},false);
+	}
+	function add_another_participant_from_file(obj)
+	{
+		let name = sanitize_groupchat_participant_name(obj.name);
+		if(name!="")
+		{
+			let names = groupchat_bot_names();
+			names.push(name);
+			set_groupchat_bot_names(names);
+			let bot_data = get_groupchat_bot_meta(name);
+			if(obj.ctx_memory)
+			{
+				bot_data.ctx_memory = obj.ctx_memory;
+				set_groupchat_bot_meta(name, bot_data);
+			}
+			if(obj.portrait)
+			{
+				compressImage(obj.portrait, (compressedImageURI, aspectratio) => {
+					bot_data.portrait = compressedImageURI;
+					bot_data.portrait_ratio = aspectratio.toFixed(2);
+					set_groupchat_bot_meta(name, bot_data);						
+				}, true, AVATAR_PX);
+			}
+			setTimeout(()=>{show_groupchat_select();},50); //give the portrait avatar some time to render
+		}
 	}
 	function confirm_groupchat_select()
 	{


### PR DESCRIPTION
As mentioned in the Discord, this upstreams the groupchat UI extension to allow importing Tavern character cards. I didn't want to hold on to it for too long, in case you're waiting on it before the next version update.

I've also taken the opportunity to patch a small issue with the `impersonate_message(` function, which currently force-closes the groupchat UI even if you decide to cancel it (by leaving the field blank). While this makes sense for one-on-one conversations, I think it's better for groupchats to keep the popup open. Not a major issue, though.