### PR TITLE
Fix: Tweak thinkblock HTML to not interfere with Markdown rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -18420,10 +18420,10 @@ Current version indicated by LITEVER below.
 					let curr = matches[matchiter];
 					curr = escape_html(curr);
 					curr = unescape_html_alternate(curr);
-					let expandedhtml = `<span><button type="button" title="Show Thoughts" class="btn btn-primary" style="font-size:12px;padding:2px 2px;" onclick="toggle_hide_thinking(this)">Show Thoughts (${curr.length} characters)</button><span class="color_lightgreen ${autoexpanded?'':'hidden'}"><br>${(curr)}\n</span><br></span>`;
+					let expandedhtml = `<span><button type="button" title="Show Thoughts" class="btn btn-primary" style="font-size:12px;padding:2px 2px;" onclick="toggle_hide_thinking(this)">Show Thoughts (${curr.length} characters)</button><span class="color_lightgreen ${autoexpanded?'':'hidden'}"><br>${(curr)}\n</span></span>\n`;
 					if(!curr || curr.trim()=="" || curr.trim()=="/nothink" || curr.trim()==`${localsettings.start_thinking_tag}${localsettings.stop_thinking_tag}`)
 					{
-						expandedhtml = `<span><button type="button" title="No Thoughts" class="btn btn-primary" style="font-size:12px;padding:2px 2px;" onclick="">No Thoughts</button><br></span>`;
+						expandedhtml = `<span><button type="button" title="No Thoughts" class="btn btn-primary" style="font-size:12px;padding:2px 2px;" onclick="">No Thoughts</button></span>\n`;
 					}
 					++matchiter;
 					return expandedhtml;


### PR DESCRIPTION
A small PR that addresses an issue raised on the Lite discord: when a think block is immediately followed by Markdown, e.g. `...thoughts<channel|># Title`, the first line is incorrectly left unformatted because the think block's `<span>` spills over into the start of the Markdown.
<img width="562" height="208" alt="image" src="https://github.com/user-attachments/assets/81056aa2-a451-4a4a-ba3d-5d2740452b3f" />

This can be resolved by a simple change to the `function apply_display_only_regex(`: end the think block's HTML code with a `\n`, so that the subsequent Markdown newline is correctly recognized.